### PR TITLE
First real draft of DITA 2.0 document types for tech comm

### DIFF
--- a/doctypes/dtd/bookmap/dtd/bookmap.dtd
+++ b/doctypes/dtd/bookmap/dtd/bookmap.dtd
@@ -72,11 +72,6 @@
          "../../technicalContent/dtd/abbreviateDomain.ent"
 >%abbrev-d-dec;
 
-<!ENTITY % delay-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delayed Resolution Domain//EN"
-         "../../base/dtd/delayResolutionDomain.ent"
->%delay-d-dec;
-
 <!ENTITY % ditavalref-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 DITAVAL Ref Domain//EN"
          "../../base/dtd/ditavalrefDomain.ent"
@@ -152,9 +147,6 @@
                          %mapgroup-d-topicref; |
                          %ditavalref-d-topicref;
                         ">
-<!ENTITY % keywords     "keywords |
-                         %delay-d-keywords;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -215,7 +207,6 @@
                           "&mapgroup-d-att;
                            &bookmap-att;
                            &abbrev-d-att;
-                           &delay-d-att;
                            &deliveryTargetAtt-d-att;
                            &ditavalref-d-att;
                            &hazard-d-att;
@@ -262,11 +253,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "../../technicalContent/dtd/abbreviateDomain.mod"
 >%abbrev-d-def;
-
-<!ENTITY % delay-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Delayed Resolution Domain//EN"
-         "../../base/dtd/delayResolutionDomain.mod"
->%delay-d-def;
 
 <!ENTITY % ditavalref-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"

--- a/doctypes/dtd/bookmap/dtd/bookmap.dtd
+++ b/doctypes/dtd/bookmap/dtd/bookmap.dtd
@@ -131,10 +131,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -193,7 +213,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -207,7 +231,11 @@
                           "&mapgroup-d-att;
                            &bookmap-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &ditavalref-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/bookmap/dtd/bookmap.dtd
+++ b/doctypes/dtd/bookmap/dtd/bookmap.dtd
@@ -92,11 +92,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "../../technicalContent/dtd/markupDomain.ent"
@@ -159,9 +154,6 @@
                         ">
 <!ENTITY % keywords     "keywords |
                          %delay-d-keywords;
-                        ">
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
                         ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
@@ -228,7 +220,6 @@
                            &ditavalref-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &pr-d-att;
                            &relmgmt-d-att;
@@ -291,11 +282,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/bookmap/dtd/bookmap.mod
+++ b/doctypes/dtd/bookmap/dtd/bookmap.mod
@@ -138,9 +138,6 @@
                copy-to
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %topicref-atts;
                %univ-atts;"
 >
@@ -234,9 +231,6 @@
                query
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                %topicref-atts;
                %univ-atts;"
 >
@@ -258,9 +252,6 @@
                           CDATA
                                     #IMPLIED
                query
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED
                %topicref-atts;
@@ -364,10 +355,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  summary %summary.content;>
 <!ATTLIST  summary %summary.attributes;>
@@ -432,9 +420,6 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                value
                           CDATA
                                     #REQUIRED"
@@ -452,10 +437,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  revisionid %revisionid.content;>
 <!ATTLIST  revisionid %revisionid.attributes;>
@@ -477,10 +459,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  started %started.content;>
 <!ATTLIST  started %started.attributes;>
@@ -502,10 +481,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  completed %completed.content;>
 <!ATTLIST  completed %completed.attributes;>
@@ -521,10 +497,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  year %year.content;>
 <!ATTLIST  year %year.attributes;>
@@ -540,10 +513,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  month %month.content;>
 <!ATTLIST  month %month.attributes;>
@@ -559,10 +529,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  day %day.content;>
 <!ATTLIST  day %day.attributes;>
@@ -686,10 +653,7 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  bookeventtype %bookeventtype.content;>
 <!ATTLIST  bookeventtype %bookeventtype.attributes;>
@@ -848,9 +812,6 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                value
                           CDATA
                                     #REQUIRED"
@@ -890,10 +851,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  booklibrary %booklibrary.content;>
 <!ATTLIST  booklibrary %booklibrary.attributes;>
@@ -909,10 +867,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  mainbooktitle %mainbooktitle.content;>
 <!ATTLIST  mainbooktitle %mainbooktitle.attributes;>
@@ -928,10 +883,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  booktitlealt %booktitlealt.content;>
 <!ATTLIST  booktitlealt %booktitlealt.attributes;>

--- a/doctypes/dtd/bookmap/dtd/bookmap.mod
+++ b/doctypes/dtd/bookmap/dtd/bookmap.mod
@@ -1148,67 +1148,67 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  bookmap      %global-atts;  class CDATA "- map/map bookmap/bookmap ">
-<!ATTLIST  abbrevlist   %global-atts;  class CDATA "- map/topicref bookmap/abbrevlist ">
-<!ATTLIST  amendments   %global-atts;  class CDATA "- map/topicref bookmap/amendments ">
-<!ATTLIST  appendices   %global-atts;  class CDATA "- map/topicref bookmap/appendices ">
-<!ATTLIST  appendix     %global-atts;  class CDATA "- map/topicref bookmap/appendix ">
-<!ATTLIST  approved     %global-atts;  class CDATA "- topic/data bookmap/approved ">
-<!ATTLIST  backmatter   %global-atts;  class CDATA "- map/topicref bookmap/backmatter ">
-<!ATTLIST  bibliolist   %global-atts;  class CDATA "- map/topicref bookmap/bibliolist ">
-<!ATTLIST  bookabstract %global-atts;  class CDATA "- map/topicref bookmap/bookabstract ">
-<!ATTLIST  bookchangehistory %global-atts;  class CDATA "- topic/data bookmap/bookchangehistory ">
-<!ATTLIST  bookevent    %global-atts;  class CDATA "- topic/data bookmap/bookevent ">
-<!ATTLIST  bookeventtype %global-atts;  class CDATA "- topic/data bookmap/bookeventtype ">
-<!ATTLIST  bookid       %global-atts;  class CDATA "- topic/data bookmap/bookid ">
-<!ATTLIST  booklibrary  %global-atts;  class CDATA "- topic/ph bookmap/booklibrary ">
-<!ATTLIST  booklist     %global-atts;  class CDATA "- map/topicref bookmap/booklist ">
-<!ATTLIST  booklists    %global-atts;  class CDATA "- map/topicref bookmap/booklists ">
-<!ATTLIST  bookmeta     %global-atts;  class CDATA "- map/topicmeta bookmap/bookmeta ">
-<!ATTLIST  booknumber   %global-atts;  class CDATA "- topic/data bookmap/booknumber ">
-<!ATTLIST  bookowner    %global-atts;  class CDATA "- topic/data bookmap/bookowner ">
-<!ATTLIST  bookpartno   %global-atts;  class CDATA "- topic/data bookmap/bookpartno ">
-<!ATTLIST  bookrestriction %global-atts;  class CDATA "- topic/data bookmap/bookrestriction ">
-<!ATTLIST  bookrights   %global-atts;  class CDATA "- topic/data bookmap/bookrights ">
-<!ATTLIST  booktitle    %global-atts;  class CDATA "- topic/title bookmap/booktitle ">
-<!ATTLIST  booktitlealt %global-atts;  class CDATA "- topic/ph bookmap/booktitlealt ">
-<!ATTLIST  chapter      %global-atts;  class CDATA "- map/topicref bookmap/chapter ">
-<!ATTLIST  colophon     %global-atts;  class CDATA "- map/topicref bookmap/colophon ">
-<!ATTLIST  completed    %global-atts;  class CDATA "- topic/ph bookmap/completed ">
-<!ATTLIST  copyrfirst   %global-atts;  class CDATA "- topic/data bookmap/copyrfirst ">
-<!ATTLIST  copyrlast    %global-atts;  class CDATA "- topic/data bookmap/copyrlast ">
-<!ATTLIST  day          %global-atts;  class CDATA "- topic/ph bookmap/day ">
-<!ATTLIST  dedication   %global-atts;  class CDATA "- map/topicref bookmap/dedication ">
-<!ATTLIST  draftintro   %global-atts;  class CDATA "- map/topicref bookmap/draftintro ">
-<!ATTLIST  edited       %global-atts;  class CDATA "- topic/data bookmap/edited ">
-<!ATTLIST  edition      %global-atts;  class CDATA "- topic/data bookmap/edition ">
-<!ATTLIST  figurelist   %global-atts;  class CDATA "- map/topicref bookmap/figurelist ">
-<!ATTLIST  frontmatter  %global-atts;  class CDATA "- map/topicref bookmap/frontmatter ">
-<!ATTLIST  glossarylist %global-atts;  class CDATA "- map/topicref bookmap/glossarylist ">
-<!ATTLIST  indexlist    %global-atts;  class CDATA "- map/topicref bookmap/indexlist ">
-<!ATTLIST  isbn         %global-atts;  class CDATA "- topic/data bookmap/isbn ">
-<!ATTLIST  mainbooktitle %global-atts;  class CDATA "- topic/ph bookmap/mainbooktitle ">
-<!ATTLIST  maintainer   %global-atts;  class CDATA "- topic/data bookmap/maintainer ">
-<!ATTLIST  month        %global-atts;  class CDATA "- topic/ph bookmap/month ">
-<!ATTLIST  notices      %global-atts;  class CDATA "- map/topicref bookmap/notices ">
-<!ATTLIST  organization %global-atts;  class CDATA "- topic/data bookmap/organization ">
-<!ATTLIST  part         %global-atts;  class CDATA "- map/topicref bookmap/part ">
-<!ATTLIST  person       %global-atts;  class CDATA "- topic/data bookmap/person ">
-<!ATTLIST  preface      %global-atts;  class CDATA "- map/topicref bookmap/preface ">
-<!ATTLIST  printlocation %global-atts;  class CDATA "- topic/data bookmap/printlocation ">
-<!ATTLIST  published    %global-atts;  class CDATA "- topic/data bookmap/published ">
-<!ATTLIST  publisherinformation %global-atts;  class CDATA "- topic/publisher bookmap/publisherinformation ">
-<!ATTLIST  publishtype  %global-atts;  class CDATA "- topic/data bookmap/publishtype ">
-<!ATTLIST  reviewed     %global-atts;  class CDATA "- topic/data bookmap/reviewed ">
-<!ATTLIST  revisionid   %global-atts;  class CDATA "- topic/ph bookmap/revisionid ">
-<!ATTLIST  started      %global-atts;  class CDATA "- topic/ph bookmap/started ">
-<!ATTLIST  summary      %global-atts;  class CDATA "- topic/ph bookmap/summary ">
-<!ATTLIST  tablelist    %global-atts;  class CDATA "- map/topicref bookmap/tablelist ">
-<!ATTLIST  tested       %global-atts;  class CDATA "- topic/data bookmap/tested ">
-<!ATTLIST  toc          %global-atts;  class CDATA "- map/topicref bookmap/toc ">
-<!ATTLIST  trademarklist %global-atts;  class CDATA "- map/topicref bookmap/trademarklist ">
-<!ATTLIST  volume       %global-atts;  class CDATA "- topic/data bookmap/volume ">
-<!ATTLIST  year         %global-atts;  class CDATA "- topic/ph bookmap/year ">
+<!ATTLIST  bookmap      class CDATA "- map/map bookmap/bookmap ">
+<!ATTLIST  abbrevlist   class CDATA "- map/topicref bookmap/abbrevlist ">
+<!ATTLIST  amendments   class CDATA "- map/topicref bookmap/amendments ">
+<!ATTLIST  appendices   class CDATA "- map/topicref bookmap/appendices ">
+<!ATTLIST  appendix     class CDATA "- map/topicref bookmap/appendix ">
+<!ATTLIST  approved     class CDATA "- topic/data bookmap/approved ">
+<!ATTLIST  backmatter   class CDATA "- map/topicref bookmap/backmatter ">
+<!ATTLIST  bibliolist   class CDATA "- map/topicref bookmap/bibliolist ">
+<!ATTLIST  bookabstract class CDATA "- map/topicref bookmap/bookabstract ">
+<!ATTLIST  bookchangehistory class CDATA "- topic/data bookmap/bookchangehistory ">
+<!ATTLIST  bookevent    class CDATA "- topic/data bookmap/bookevent ">
+<!ATTLIST  bookeventtype class CDATA "- topic/data bookmap/bookeventtype ">
+<!ATTLIST  bookid       class CDATA "- topic/data bookmap/bookid ">
+<!ATTLIST  booklibrary  class CDATA "- topic/ph bookmap/booklibrary ">
+<!ATTLIST  booklist     class CDATA "- map/topicref bookmap/booklist ">
+<!ATTLIST  booklists    class CDATA "- map/topicref bookmap/booklists ">
+<!ATTLIST  bookmeta     class CDATA "- map/topicmeta bookmap/bookmeta ">
+<!ATTLIST  booknumber   class CDATA "- topic/data bookmap/booknumber ">
+<!ATTLIST  bookowner    class CDATA "- topic/data bookmap/bookowner ">
+<!ATTLIST  bookpartno   class CDATA "- topic/data bookmap/bookpartno ">
+<!ATTLIST  bookrestriction class CDATA "- topic/data bookmap/bookrestriction ">
+<!ATTLIST  bookrights   class CDATA "- topic/data bookmap/bookrights ">
+<!ATTLIST  booktitle    class CDATA "- topic/title bookmap/booktitle ">
+<!ATTLIST  booktitlealt class CDATA "- topic/ph bookmap/booktitlealt ">
+<!ATTLIST  chapter      class CDATA "- map/topicref bookmap/chapter ">
+<!ATTLIST  colophon     class CDATA "- map/topicref bookmap/colophon ">
+<!ATTLIST  completed    class CDATA "- topic/ph bookmap/completed ">
+<!ATTLIST  copyrfirst   class CDATA "- topic/data bookmap/copyrfirst ">
+<!ATTLIST  copyrlast    class CDATA "- topic/data bookmap/copyrlast ">
+<!ATTLIST  day          class CDATA "- topic/ph bookmap/day ">
+<!ATTLIST  dedication   class CDATA "- map/topicref bookmap/dedication ">
+<!ATTLIST  draftintro   class CDATA "- map/topicref bookmap/draftintro ">
+<!ATTLIST  edited       class CDATA "- topic/data bookmap/edited ">
+<!ATTLIST  edition      class CDATA "- topic/data bookmap/edition ">
+<!ATTLIST  figurelist   class CDATA "- map/topicref bookmap/figurelist ">
+<!ATTLIST  frontmatter  class CDATA "- map/topicref bookmap/frontmatter ">
+<!ATTLIST  glossarylist class CDATA "- map/topicref bookmap/glossarylist ">
+<!ATTLIST  indexlist    class CDATA "- map/topicref bookmap/indexlist ">
+<!ATTLIST  isbn         class CDATA "- topic/data bookmap/isbn ">
+<!ATTLIST  mainbooktitle class CDATA "- topic/ph bookmap/mainbooktitle ">
+<!ATTLIST  maintainer   class CDATA "- topic/data bookmap/maintainer ">
+<!ATTLIST  month        class CDATA "- topic/ph bookmap/month ">
+<!ATTLIST  notices      class CDATA "- map/topicref bookmap/notices ">
+<!ATTLIST  organization class CDATA "- topic/data bookmap/organization ">
+<!ATTLIST  part         class CDATA "- map/topicref bookmap/part ">
+<!ATTLIST  person       class CDATA "- topic/data bookmap/person ">
+<!ATTLIST  preface      class CDATA "- map/topicref bookmap/preface ">
+<!ATTLIST  printlocation class CDATA "- topic/data bookmap/printlocation ">
+<!ATTLIST  published    class CDATA "- topic/data bookmap/published ">
+<!ATTLIST  publisherinformation class CDATA "- topic/publisher bookmap/publisherinformation ">
+<!ATTLIST  publishtype  class CDATA "- topic/data bookmap/publishtype ">
+<!ATTLIST  reviewed     class CDATA "- topic/data bookmap/reviewed ">
+<!ATTLIST  revisionid   class CDATA "- topic/ph bookmap/revisionid ">
+<!ATTLIST  started      class CDATA "- topic/ph bookmap/started ">
+<!ATTLIST  summary      class CDATA "- topic/ph bookmap/summary ">
+<!ATTLIST  tablelist    class CDATA "- map/topicref bookmap/tablelist ">
+<!ATTLIST  tested       class CDATA "- topic/data bookmap/tested ">
+<!ATTLIST  toc          class CDATA "- map/topicref bookmap/toc ">
+<!ATTLIST  trademarklist class CDATA "- map/topicref bookmap/trademarklist ">
+<!ATTLIST  volume       class CDATA "- topic/data bookmap/volume ">
+<!ATTLIST  year         class CDATA "- topic/ph bookmap/year ">
 
 <!-- ================== End of DITA Bookmap ==================== -->
  

--- a/doctypes/dtd/bookmap/dtd/bookmap.mod
+++ b/doctypes/dtd/bookmap/dtd/bookmap.mod
@@ -123,10 +123,7 @@
 <!-- ============================================================= -->
 
 <!ENTITY % chapter-atts
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref

--- a/doctypes/dtd/catalog.xml
+++ b/doctypes/dtd/catalog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
    <nextCatalog catalog="bookmap/catalog.xml"/>
+   <nextCatalog catalog="classificationMap/catalog.xml"/>
    <nextCatalog catalog="machineryIndustry/catalog.xml"/>
    <nextCatalog catalog="technicalContent/catalog.xml"/>
    <nextCatalog catalog="xnal/catalog.xml"/>

--- a/doctypes/dtd/classificationMap/catalog.xml
+++ b/doctypes/dtd/classificationMap/catalog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+<!--DITA Subject Classification Domain-->
+   <public publicId="-//OASIS//DTD DITA 2.0 Classification Map//EN"
+           uri="classifyMap.dtd"/>
+   <!--<public publicId="-//OASIS//DTD DITA 1.x Classification Map//EN"
+           uri="dtd/classifyMap.dtd"/>
+   <public publicId="-//OASIS//DTD DITA Classification Map//EN"
+           uri="dtd/classifyMap.dtd"/>-->
+</catalog>

--- a/doctypes/dtd/classificationMap/classifyMap.dtd
+++ b/doctypes/dtd/classificationMap/classifyMap.dtd
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
+<!-- OASIS Standard                                           -->
+<!-- 16 January 2018                                           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!--  MODULE:    DITA Classification Map                           -->
+<!--  VERSION:   1.3                                               -->
+<!--  DATE:      November 2014                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--                                                               -->
+<!-- Refer to this file by the following public identifier or an   -->
+<!--      appropriate system identifier:                           -->
+<!-- PUBLIC "-//OASIS//DTD DITA Classification Map//EN"            -->
+<!--      Delivered as file "classifyMap.dtd"                           -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Darwin Information Typing Architecture (DITA)     -->
+<!--                                                               -->
+<!-- PURPOSE:    DTD to describe DITA Classification maps          -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             March 2001                                        -->
+<!--                                                               -->
+<!--             (C) Copyright OASIS Open 2005, 2014.              -->
+<!--             (C) Copyright IBM Corporation 2001, 2004.         -->
+<!--             All Rights Reserved.                              -->
+<!--                                                               -->
+<!--  UPDATES:                                                     -->
+<!--    2010.09.21 RDA: Added base topic domains                   -->
+<!--    2014.03.13 WEK: Updated for DITA 1.3, reimplemented as RNG -->
+<!-- ============================================================= -->
+<!--                                                               -->
+<!--                                                               -->
+
+<!-- ============================================================= -->
+<!--                MAP ENTITY DECLARATIONS                        -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--             DOMAIN ENTITY DECLARATIONS                        -->
+<!-- ============================================================= -->
+
+<!ENTITY % mapgroup-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Map Group Domain//EN"
+         "../../base/dtd/mapGroup.ent"
+>%mapgroup-d-dec;
+
+<!ENTITY % classify-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Subject Classification Domain//EN"
+         "classifyDomain.ent"
+>%classify-d-dec;
+
+<!ENTITY % abbrev-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Abbreviated Form Domain//EN"
+         "../../technicalContent/dtd/abbreviateDomain.ent"
+>%abbrev-d-dec;
+
+<!ENTITY % ditavalref-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 DITAVAL Ref Domain//EN"
+         "../../base/dtd/ditavalrefDomain.ent"
+>%ditavalref-d-dec;
+
+<!ENTITY % glossref-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Glossary Reference Domain//EN"
+         "../../technicalContent/dtd/glossrefDomain.ent"
+>%glossref-d-dec;
+
+<!ENTITY % hazard-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Hazard Statement Domain//EN"
+         "../../base/dtd/hazardstatementDomain.ent"
+>%hazard-d-dec;
+
+<!ENTITY % hi-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Highlight Domain//EN"
+         "../../base/dtd/highlightDomain.ent"
+>%hi-d-dec;
+
+<!ENTITY % markup-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
+         "../../technicalContent/dtd/markupDomain.ent"
+>%markup-d-dec;
+
+<!ENTITY % pr-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Programming Domain//EN"
+         "../../technicalContent/dtd/programmingDomain.ent"
+>%pr-d-dec;
+
+<!ENTITY % relmgmt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Release Management Domain//EN"
+         "../../technicalContent/dtd/releaseManagementDomain.ent"
+>%relmgmt-d-dec;
+
+<!ENTITY % sw-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Software Domain//EN"
+         "../../technicalContent/dtd/softwareDomain.ent"
+>%sw-d-dec;
+
+<!ENTITY % ui-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 User Interface Domain//EN"
+         "../../technicalContent/dtd/uiDomain.ent"
+>%ui-d-dec;
+
+<!ENTITY % ut-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Utilities Domain//EN"
+         "../../base/dtd/utilitiesDomain.ent"
+>%ut-d-dec;
+
+<!ENTITY % xml-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 XML Domain//EN"
+         "../../technicalContent/dtd/xmlDomain.ent"
+>%xml-d-dec;
+
+<!-- ============================================================= -->
+<!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
+<!-- ============================================================= -->
+
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
+<!ENTITY % deliveryTargetAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
+         "deliveryTargetAttDomain.ent"
+>%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
+
+<!-- ============================================================= -->
+<!--                    DOMAIN EXTENSIONS                          -->
+<!-- ============================================================= -->
+<!--                    One for each extended base element, with
+                        the name of the domain(s) in which the
+                        extension was declared                     -->
+
+<!ENTITY % topicref     "topicref |
+                         %mapgroup-d-topicref; |
+                         %ditavalref-d-topicref; |
+                         %classify-d-topicref; |
+                         %glossref-d-topicref;
+                        ">
+<!ENTITY % note         "note |
+                         %hazard-d-note;
+                        ">
+<!ENTITY % ph           "ph |
+                         %hi-d-ph; |
+                         %pr-d-ph; |
+                         %sw-d-ph; |
+                         %ui-d-ph;
+                        ">
+<!ENTITY % fig          "fig |
+                         %ut-d-fig; |
+                         %pr-d-fig;
+                        ">
+<!ENTITY % data         "data |
+                         %ut-d-data;
+                        ">
+<!ENTITY % term         "term |
+                         %abbrev-d-term;
+                        ">
+<!ENTITY % keyword      "keyword |
+                         %markup-d-keyword; |
+                         %pr-d-keyword; |
+                         %sw-d-keyword; |
+                         %ui-d-keyword; |
+                         %xml-d-keyword;
+                        ">
+<!ENTITY % pre          "pre |
+                         %pr-d-pre; |
+                         %sw-d-pre; |
+                         %ui-d-pre;
+                        ">
+<!ENTITY % dl           "dl |
+                         %pr-d-dl;
+                        ">
+<!ENTITY % metadata     "metadata |
+                         %relmgmt-d-metadata;
+                        ">
+<!ENTITY % reltable     "reltable |
+                         %classify-d-reltable;
+                        ">
+
+<!-- ============================================================= -->
+<!--                    DOMAIN ATTRIBUTE EXTENSIONS                -->
+<!-- ============================================================= -->
+
+<!ENTITY % props-attribute-extensions
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
+>
+<!ENTITY % base-attribute-extensions
+  ""
+>
+
+<!-- ============================================================= -->
+<!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
+<!-- ============================================================= -->
+
+<!ENTITY included-domains
+                          "&mapgroup-d-att;
+                           &classify-d-att;
+                           &abbrev-d-att;
+                           &audienceAtt-d-att;
+                           &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
+                           &ditavalref-d-att;
+                           &glossref-d-att;
+                           &hazard-d-att;
+                           &hi-d-att;
+                           &markup-d-att;
+                           &pr-d-att;
+                           &relmgmt-d-att;
+                           &sw-d-att;
+                           &ui-d-att;
+                           &ut-d-att;
+                           &xml-d-att;
+  "
+>
+
+<!-- ============================================================= -->
+<!--                    CONTENT CONSTRAINT INTEGRATION             -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                      MAP ELEMENT INTEGRATION                  -->
+<!-- ============================================================= -->
+
+<!ENTITY % map-type
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map//EN"
+         "../../base/dtd/map.mod"
+>%map-type;
+
+<!-- ============================================================= -->
+<!--                    DOMAIN ELEMENT INTEGRATION                 -->
+<!-- ============================================================= -->
+
+<!ENTITY % mapgroup-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Map Group Domain//EN"
+         "../../base/dtd/mapGroup.mod"
+>%mapgroup-d-def;
+
+<!ENTITY % classify-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Subject Classification Domain//EN"
+         "classifyDomain.mod"
+>%classify-d-def;
+
+<!ENTITY % abbrev-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
+         "../../technicalContent/dtd/abbreviateDomain.mod"
+>%abbrev-d-def;
+
+<!ENTITY % ditavalref-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
+         "../../base/dtd/ditavalrefDomain.mod"
+>%ditavalref-d-def;
+
+<!ENTITY % glossref-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Reference Domain//EN"
+         "../../technicalContent/dtd/glossrefDomain.mod"
+>%glossref-d-def;
+
+<!ENTITY % hazard-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"
+         "../../base/dtd/hazardstatementDomain.mod"
+>%hazard-d-def;
+
+<!ENTITY % hi-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
+         "../../base/dtd/highlightDomain.mod"
+>%hi-d-def;
+
+<!ENTITY % markup-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"
+         "../../technicalContent/dtd/markupDomain.mod"
+>%markup-d-def;
+
+<!ENTITY % pr-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Programming Domain//EN"
+         "../../technicalContent/dtd/programmingDomain.mod"
+>%pr-d-def;
+
+<!ENTITY % relmgmt-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Release Management Domain//EN"
+         "../../technicalContent/dtd/releaseManagementDomain.mod"
+>%relmgmt-d-def;
+
+<!ENTITY % sw-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Software Domain//EN"
+         "../../technicalContent/dtd/softwareDomain.mod"
+>%sw-d-def;
+
+<!ENTITY % ui-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 User Interface Domain//EN"
+         "../../technicalContent/dtd/uiDomain.mod"
+>%ui-d-def;
+
+<!ENTITY % ut-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
+         "../../base/dtd/utilitiesDomain.mod"
+>%ut-d-def;
+
+<!ENTITY % xml-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 XML Domain//EN"
+         "../../technicalContent/dtd/xmlDomain.mod"
+>%xml-d-def;
+
+<!-- ================= End of DITA Classification Map Shell ================= -->

--- a/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
+++ b/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
@@ -90,10 +90,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -136,7 +156,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -156,7 +180,11 @@
 
 <!ENTITY included-domains
                           "&task-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &hazard-d-att;
                            &hi-d-att;
                            &svg-d-att;

--- a/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
+++ b/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
@@ -66,11 +66,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % svg-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 SVG Domain//EN"
          "../../technicalContent/dtd/svgDomain.ent"
@@ -107,9 +102,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -167,7 +159,6 @@
                            &deliveryTargetAtt-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &svg-d-att;
                            &taskreq-d-att;
                            &ui-d-att;
@@ -212,11 +203,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % svg-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 SVG Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/abbreviateDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/abbreviateDomain.mod
@@ -50,10 +50,7 @@
               "keyref
                           CDATA
                                     #REQUIRED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  abbreviated-form %abbreviated-form.content;>
 <!ATTLIST  abbreviated-form %abbreviated-form.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/abbreviateDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/abbreviateDomain.mod
@@ -61,7 +61,7 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  abbreviated-form %global-atts;  class CDATA "+ topic/term abbrev-d/abbreviated-form ">
+<!ATTLIST  abbreviated-form class CDATA "+ topic/term abbrev-d/abbreviated-form ">
 
 <!-- ================== End of DITA Abbreviated Form Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/concept.dtd
+++ b/doctypes/dtd/technicalContent/dtd/concept.dtd
@@ -133,10 +133,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -197,7 +217,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -218,7 +242,11 @@
 <!ENTITY included-domains
                           "&concept-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/concept.dtd
+++ b/doctypes/dtd/technicalContent/dtd/concept.dtd
@@ -84,11 +84,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -150,9 +145,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -230,7 +222,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &mathml-d-att;
                            &pr-d-att;
@@ -284,11 +275,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/concept.mod
+++ b/doctypes/dtd/technicalContent/dtd/concept.mod
@@ -114,10 +114,7 @@
                          %section;)*"
 >
 <!ENTITY % conbodydiv.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  conbodydiv %conbodydiv.content;>
 <!ATTLIST  conbodydiv %conbodydiv.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/concept.mod
+++ b/doctypes/dtd/technicalContent/dtd/concept.mod
@@ -125,9 +125,9 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  concept      %global-atts;  class CDATA "- topic/topic concept/concept ">
-<!ATTLIST  conbody      %global-atts;  class CDATA "- topic/body  concept/conbody ">
-<!ATTLIST  conbodydiv   %global-atts;  class CDATA "- topic/bodydiv concept/conbodydiv ">
+<!ATTLIST  concept      class CDATA "- topic/topic concept/concept ">
+<!ATTLIST  conbody      class CDATA "- topic/body  concept/conbody ">
+<!ATTLIST  conbodydiv   class CDATA "- topic/bodydiv concept/conbodydiv ">
 
 <!-- ================== End of DITA Concept ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/dtd/ditabase.dtd
@@ -414,7 +414,6 @@
                                   "&included-domains;"
               %arch-atts;
               %localization-atts;
-              %global-atts;
 >
 
 <!-- ================= End of DITA BASE ================= -->

--- a/doctypes/dtd/technicalContent/dtd/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/dtd/ditabase.dtd
@@ -114,11 +114,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -180,9 +175,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -286,7 +278,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &mathml-d-att;
                            &pr-d-att;
@@ -371,11 +362,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/dtd/ditabase.dtd
@@ -163,10 +163,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -227,7 +247,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -274,7 +298,11 @@
                            &reference-att;
                            &troubleshooting-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/equationDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/equationDomain.mod
@@ -88,10 +88,10 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  equation-inline %global-atts;  class CDATA "+ topic/ph equation-d/equation-inline ">
-<!ATTLIST  equation-block %global-atts;  class CDATA "+ topic/div equation-d/equation-block ">
-<!ATTLIST  equation-number %global-atts;  class CDATA "+ topic/ph equation-d/equation-number ">
-<!ATTLIST  equation-figure %global-atts;  class CDATA "+ topic/fig equation-d/equation-figure ">
+<!ATTLIST  equation-inline class CDATA "+ topic/ph equation-d/equation-inline ">
+<!ATTLIST  equation-block class CDATA "+ topic/div equation-d/equation-block ">
+<!ATTLIST  equation-number class CDATA "+ topic/ph equation-d/equation-number ">
+<!ATTLIST  equation-figure class CDATA "+ topic/fig equation-d/equation-figure ">
 
 <!-- ================== End of DITA Equation Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/equationDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/equationDomain.mod
@@ -34,10 +34,7 @@
                        "(%equation.cnt;)*"
 >
 <!ENTITY % equation-inline.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  equation-inline %equation-inline.content;>
 <!ATTLIST  equation-inline %equation-inline.attributes;>
@@ -49,10 +46,7 @@
                          %equation-number;)*"
 >
 <!ENTITY % equation-block.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  equation-block %equation-block.content;>
 <!ATTLIST  equation-block %equation-block.attributes;>
@@ -65,10 +59,7 @@
                          %text;)*"
 >
 <!ENTITY % equation-number.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  equation-number %equation-number.content;>
 <!ATTLIST  equation-number %equation-number.attributes;>
@@ -86,10 +77,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  equation-figure %equation-figure.content;>
 <!ATTLIST  equation-figure %equation-figure.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/generalTask.dtd
+++ b/doctypes/dtd/technicalContent/dtd/generalTask.dtd
@@ -80,11 +80,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -146,9 +141,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -226,7 +218,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &mathml-d-att;
                            &pr-d-att;
@@ -280,11 +271,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/generalTask.dtd
+++ b/doctypes/dtd/technicalContent/dtd/generalTask.dtd
@@ -129,10 +129,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -193,7 +213,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -214,7 +238,11 @@
 <!ENTITY included-domains
                           "&task-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/glossentry.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.dtd
@@ -84,11 +84,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % abbrev-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.ent"
@@ -155,9 +150,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -235,7 +227,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &abbrev-d-att;
                            &markup-d-att;
                            &mathml-d-att;
@@ -290,11 +281,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % abbrev-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/glossentry.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.dtd
@@ -138,10 +138,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -202,7 +222,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -223,7 +247,11 @@
 <!ENTITY included-domains
                           "&concept-att;
                            &glossentry-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/glossentry.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.mod
@@ -127,10 +127,7 @@
                        "(%abstract.cnt;)*"
 >
 <!ENTITY % glossdef.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  glossdef %glossdef.content;>
 <!ATTLIST  glossdef %glossdef.attributes;>
@@ -297,10 +294,7 @@
                          %tm;)*"
 >
 <!ENTITY % glossSurfaceForm.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  glossSurfaceForm %glossSurfaceForm.content;>
 <!ATTLIST  glossSurfaceForm %glossSurfaceForm.attributes;>
@@ -329,10 +323,7 @@
                othertype
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  glossUsage %glossUsage.content;>
 <!ATTLIST  glossUsage %glossUsage.attributes;>
@@ -361,10 +352,7 @@
                othertype
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  glossScopeNote %glossScopeNote.content;>
 <!ATTLIST  glossScopeNote %glossScopeNote.attributes;>
@@ -413,10 +401,7 @@
                            inline |
                            -dita-use-conref-target)
                                     'inline'
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  glossSymbol %glossSymbol.content;>
 <!ATTLIST  glossSymbol %glossSymbol.attributes;>
@@ -435,10 +420,7 @@
                          (%glossAlternateFor;)*)"
 >
 <!ENTITY % glossAlt.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  glossAlt %glossAlt.content;>
 <!ATTLIST  glossAlt %glossAlt.attributes;>
@@ -467,10 +449,7 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  glossAlternateFor %glossAlternateFor.content;>
 <!ATTLIST  glossAlternateFor %glossAlternateFor.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/glossentry.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.mod
@@ -460,23 +460,23 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  glossentry   %global-atts;  class CDATA "- topic/topic concept/concept glossentry/glossentry ">
-<!ATTLIST  glossterm    %global-atts;  class CDATA "- topic/title concept/title glossentry/glossterm ">
-<!ATTLIST  glossdef     %global-atts;  class CDATA "- topic/abstract concept/abstract glossentry/glossdef ">
-<!ATTLIST  glossBody    %global-atts;  class CDATA "- topic/body concept/conbody glossentry/glossBody ">
-<!ATTLIST  glossAbbreviation %global-atts;  class CDATA "- topic/title concept/title glossentry/glossAbbreviation ">
-<!ATTLIST  glossAcronym %global-atts;  class CDATA "- topic/title concept/title glossentry/glossAcronym ">
-<!ATTLIST  glossShortForm %global-atts;  class CDATA "- topic/title concept/title glossentry/glossShortForm ">
-<!ATTLIST  glossSynonym %global-atts;  class CDATA "- topic/title concept/title glossentry/glossSynonym ">
-<!ATTLIST  glossPartOfSpeech %global-atts;  class CDATA "- topic/data concept/data glossentry/glossPartOfSpeech ">
-<!ATTLIST  glossProperty %global-atts;  class CDATA "- topic/data concept/data glossentry/glossProperty ">
-<!ATTLIST  glossStatus  %global-atts;  class CDATA "- topic/data concept/data glossentry/glossStatus ">
-<!ATTLIST  glossAlt     %global-atts;  class CDATA "- topic/section concept/section glossentry/glossAlt ">
-<!ATTLIST  glossAlternateFor %global-atts;  class CDATA "- topic/xref concept/xref glossentry/glossAlternateFor ">
-<!ATTLIST  glossScopeNote %global-atts;  class CDATA "- topic/note concept/note glossentry/glossScopeNote ">
-<!ATTLIST  glossSurfaceForm %global-atts;  class CDATA "- topic/p concept/p glossentry/glossSurfaceForm ">
-<!ATTLIST  glossSymbol  %global-atts;  class CDATA "- topic/image concept/image glossentry/glossSymbol ">
-<!ATTLIST  glossUsage   %global-atts;  class CDATA "- topic/note concept/note glossentry/glossUsage ">
+<!ATTLIST  glossentry   class CDATA "- topic/topic concept/concept glossentry/glossentry ">
+<!ATTLIST  glossterm    class CDATA "- topic/title concept/title glossentry/glossterm ">
+<!ATTLIST  glossdef     class CDATA "- topic/abstract concept/abstract glossentry/glossdef ">
+<!ATTLIST  glossBody    class CDATA "- topic/body concept/conbody glossentry/glossBody ">
+<!ATTLIST  glossAbbreviation class CDATA "- topic/title concept/title glossentry/glossAbbreviation ">
+<!ATTLIST  glossAcronym class CDATA "- topic/title concept/title glossentry/glossAcronym ">
+<!ATTLIST  glossShortForm class CDATA "- topic/title concept/title glossentry/glossShortForm ">
+<!ATTLIST  glossSynonym class CDATA "- topic/title concept/title glossentry/glossSynonym ">
+<!ATTLIST  glossPartOfSpeech class CDATA "- topic/data concept/data glossentry/glossPartOfSpeech ">
+<!ATTLIST  glossProperty class CDATA "- topic/data concept/data glossentry/glossProperty ">
+<!ATTLIST  glossStatus  class CDATA "- topic/data concept/data glossentry/glossStatus ">
+<!ATTLIST  glossAlt     class CDATA "- topic/section concept/section glossentry/glossAlt ">
+<!ATTLIST  glossAlternateFor class CDATA "- topic/xref concept/xref glossentry/glossAlternateFor ">
+<!ATTLIST  glossScopeNote class CDATA "- topic/note concept/note glossentry/glossScopeNote ">
+<!ATTLIST  glossSurfaceForm class CDATA "- topic/p concept/p glossentry/glossSurfaceForm ">
+<!ATTLIST  glossSymbol  class CDATA "- topic/image concept/image glossentry/glossSymbol ">
+<!ATTLIST  glossUsage   class CDATA "- topic/note concept/note glossentry/glossUsage ">
 
 <!-- ================== End of DITA Glossary Entry ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
@@ -134,10 +134,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -198,7 +218,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -226,7 +250,11 @@
                           "&concept-att;
                            &glossentry-att;
                            &glossgroup-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
@@ -80,11 +80,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % abbrev-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.ent"
@@ -151,9 +146,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -238,7 +230,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &abbrev-d-att;
                            &markup-d-att;
                            &mathml-d-att;
@@ -298,11 +289,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % abbrev-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/glossgroup.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossgroup.mod
@@ -75,7 +75,7 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  glossgroup   %global-atts;  class CDATA "- topic/topic concept/concept glossgroup/glossgroup ">
+<!ATTLIST  glossgroup   class CDATA "- topic/topic concept/concept glossgroup/glossgroup ">
 
 <!-- ================== End of DITA Glossary Group ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
@@ -46,10 +46,7 @@
                        "(%topicmeta;)?"
 >
 <!ENTITY % glossref.attributes
-              "navtitle
-                          CDATA
-                                    #IMPLIED
-               href
+              "href
                           CDATA
                                     #IMPLIED
                keyref

--- a/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
@@ -130,7 +130,7 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  glossref     %global-atts;  class CDATA "+ map/topicref glossref-d/glossref ">
+<!ATTLIST  glossref     class CDATA "+ map/topicref glossref-d/glossref ">
 
 <!-- ================== End of DITA Glossary Reference Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
@@ -64,9 +64,6 @@
                copy-to
                           CDATA
                                     #IMPLIED
-               outputclass
-                          CDATA
-                                    #IMPLIED
                collection-type
                           (choice |
                            family |

--- a/doctypes/dtd/technicalContent/dtd/map.dtd
+++ b/doctypes/dtd/technicalContent/dtd/map.dtd
@@ -98,11 +98,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -161,9 +156,6 @@
                         ">
 <!ENTITY % keywords     "keywords |
                          %delay-d-keywords;
-                        ">
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
                         ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
@@ -227,7 +219,6 @@
                            &glossref-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &pr-d-att;
                            &relmgmt-d-att;
@@ -289,11 +280,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/map.dtd
+++ b/doctypes/dtd/technicalContent/dtd/map.dtd
@@ -73,11 +73,6 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
-<!ENTITY % delay-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delayed Resolution Domain//EN"
-         "../../base/dtd/delayResolutionDomain.ent"
->%delay-d-dec;
-
 <!ENTITY % ditavalref-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 DITAVAL Ref Domain//EN"
          "../../base/dtd/ditavalrefDomain.ent"
@@ -154,9 +149,6 @@
                          %ditavalref-d-topicref; |
                          %glossref-d-topicref;
                         ">
-<!ENTITY % keywords     "keywords |
-                         %delay-d-keywords;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -213,7 +205,6 @@
 <!ENTITY included-domains
                           "&mapgroup-d-att;
                            &abbrev-d-att;
-                           &delay-d-att;
                            &deliveryTargetAtt-d-att;
                            &ditavalref-d-att;
                            &glossref-d-att;
@@ -255,11 +246,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
-
-<!ENTITY % delay-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Delayed Resolution Domain//EN"
-         "../../base/dtd/delayResolutionDomain.mod"
->%delay-d-def;
 
 <!ENTITY % ditavalref-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/map.dtd
+++ b/doctypes/dtd/technicalContent/dtd/map.dtd
@@ -132,10 +132,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -192,7 +212,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -205,7 +229,11 @@
 <!ENTITY included-domains
                           "&mapgroup-d-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &ditavalref-d-att;
                            &glossref-d-att;
                            &hazard-d-att;

--- a/doctypes/dtd/technicalContent/dtd/markupDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/markupDomain.mod
@@ -28,10 +28,7 @@
                          %text;)*"
 >
 <!ENTITY % markupname.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  markupname %markupname.content;>
 <!ATTLIST  markupname %markupname.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/markupDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/markupDomain.mod
@@ -39,7 +39,7 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  markupname   %global-atts;  class CDATA "+ topic/keyword markup-d/markupname ">
+<!ATTLIST  markupname   class CDATA "+ topic/keyword markup-d/markupname ">
 
 <!-- ================== End of DITA Markup Name Mention Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
@@ -55,10 +55,7 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  mathmlref %mathmlref.content;>
 <!ATTLIST  mathmlref %mathmlref.attributes;>
@@ -72,10 +69,7 @@
                          %data-about;)*"
 >
 <!ENTITY % mathml.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  mathml %mathml.content;>
 <!ATTLIST  mathml %mathml.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
@@ -80,8 +80,8 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  mathml       %global-atts;  class CDATA "+ topic/foreign mathml-d/mathml ">
-<!ATTLIST  mathmlref    %global-atts;  class CDATA "+ topic/xref mathml-d/mathmlref ">
+<!ATTLIST  mathml       class CDATA "+ topic/foreign mathml-d/mathml ">
+<!ATTLIST  mathmlref    class CDATA "+ topic/xref mathml-d/mathmlref ">
 
 <!-- ================== End of DITA MathML Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
@@ -87,6 +87,9 @@
                %id-atts;
                %filter-atts;
                %localization-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED
                rev
                           CDATA
                                     #IMPLIED
@@ -108,10 +111,7 @@
                          %required-cleanup;)*"
 >
 <!ENTITY % codeph.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  codeph %codeph.content;>
 <!ATTLIST  codeph %codeph.attributes;>
@@ -135,10 +135,7 @@
                           (preserve)
                                     #FIXED 
                                     'preserve'
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  codeblock %codeblock.content;>
 <!ATTLIST  codeblock %codeblock.attributes;>
@@ -167,10 +164,7 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  coderef %coderef.content;>
 <!ATTLIST  coderef %coderef.attributes;>
@@ -185,10 +179,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  option %option.content;>
 <!ATTLIST  option %option.attributes;>
@@ -205,10 +196,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  var %var.content;>
 <!ATTLIST  var %var.attributes;>
@@ -223,10 +211,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  parmname %parmname.content;>
 <!ATTLIST  parmname %parmname.attributes;>
@@ -247,10 +232,7 @@
                          %var;)*"
 >
 <!ENTITY % synph.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  synph %synph.content;>
 <!ATTLIST  synph %synph.attributes;>
@@ -267,10 +249,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  oper %oper.content;>
 <!ATTLIST  oper %oper.attributes;>
@@ -286,10 +265,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  delim %delim.content;>
 <!ATTLIST  delim %delim.attributes;>
@@ -305,10 +281,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  sep %sep.content;>
 <!ATTLIST  sep %sep.attributes;>
@@ -323,10 +296,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  apiname %apiname.content;>
 <!ATTLIST  apiname %apiname.attributes;>
@@ -347,10 +317,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  parml %parml.content;>
 <!ATTLIST  parml %parml.attributes;>
@@ -362,10 +329,7 @@
                          (%pd;)+)"
 >
 <!ENTITY % plentry.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  plentry %plentry.content;>
 <!ATTLIST  plentry %plentry.attributes;>
@@ -379,10 +343,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  pt %pt.content;>
 <!ATTLIST  pt %pt.attributes;>
@@ -393,10 +354,7 @@
                        "(%defn.cnt;)*"
 >
 <!ENTITY % pd.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  pd %pd.content;>
 <!ATTLIST  pd %pd.attributes;>
@@ -416,10 +374,7 @@
 >
 <!ENTITY % syntaxdiagram.attributes
               "%display-atts;
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  syntaxdiagram %syntaxdiagram.content;>
 <!ATTLIST  syntaxdiagram %syntaxdiagram.attributes;>
@@ -437,10 +392,7 @@
                           %synnoteref;)*)"
 >
 <!ENTITY % synblk.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  synblk %synblk.content;>
 <!ATTLIST  synblk %synblk.attributes;>
@@ -469,10 +421,7 @@
                            optional |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  groupseq %groupseq.content;>
 <!ATTLIST  groupseq %groupseq.attributes;>
@@ -501,10 +450,7 @@
                            optional |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  groupchoice %groupchoice.content;>
 <!ATTLIST  groupchoice %groupchoice.attributes;>
@@ -533,10 +479,7 @@
                            optional |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  groupcomp %groupcomp.content;>
 <!ATTLIST  groupcomp %groupcomp.attributes;>
@@ -553,10 +496,7 @@
                           %synnoteref;)*)"
 >
 <!ENTITY % fragment.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  fragment %fragment.content;>
 <!ATTLIST  fragment %fragment.attributes;>
@@ -575,10 +515,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  fragref %fragref.content;>
 <!ATTLIST  fragref %fragref.attributes;>
@@ -593,10 +530,7 @@
               "callout
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  synnote %synnote.content;>
 <!ATTLIST  synnote %synnote.attributes;>
@@ -610,10 +544,7 @@
               "href
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  synnoteref %synnoteref.content;>
 <!ATTLIST  synnoteref %synnoteref.attributes;>
@@ -629,10 +560,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  repsep %repsep.content;>
 <!ATTLIST  repsep %repsep.attributes;>
@@ -653,10 +581,7 @@
                            optional |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance;"
 >
 <!ELEMENT  kwd %kwd.content;>
 <!ATTLIST  kwd %kwd.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
@@ -592,32 +592,32 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  apiname      %global-atts;  class CDATA "+ topic/keyword pr-d/apiname ">
-<!ATTLIST  codeblock    %global-atts;  class CDATA "+ topic/pre pr-d/codeblock ">
-<!ATTLIST  codeph       %global-atts;  class CDATA "+ topic/ph pr-d/codeph ">
-<!ATTLIST  coderef      %global-atts;  class CDATA "+ topic/xref pr-d/coderef ">
-<!ATTLIST  delim        %global-atts;  class CDATA "+ topic/ph pr-d/delim ">
-<!ATTLIST  fragment     %global-atts;  class CDATA "+ topic/figgroup pr-d/fragment ">
-<!ATTLIST  fragref      %global-atts;  class CDATA "+ topic/xref pr-d/fragref ">
-<!ATTLIST  groupchoice  %global-atts;  class CDATA "+ topic/figgroup pr-d/groupchoice ">
-<!ATTLIST  groupcomp    %global-atts;  class CDATA "+ topic/figgroup pr-d/groupcomp ">
-<!ATTLIST  groupseq     %global-atts;  class CDATA "+ topic/figgroup pr-d/groupseq ">
-<!ATTLIST  kwd          %global-atts;  class CDATA "+ topic/keyword pr-d/kwd ">
-<!ATTLIST  oper         %global-atts;  class CDATA "+ topic/ph pr-d/oper ">
-<!ATTLIST  option       %global-atts;  class CDATA "+ topic/keyword pr-d/option ">
-<!ATTLIST  parml        %global-atts;  class CDATA "+ topic/dl pr-d/parml ">
-<!ATTLIST  parmname     %global-atts;  class CDATA "+ topic/keyword pr-d/parmname ">
-<!ATTLIST  pd           %global-atts;  class CDATA "+ topic/dd pr-d/pd " >
-<!ATTLIST  plentry      %global-atts;  class CDATA "+ topic/dlentry pr-d/plentry ">
-<!ATTLIST  pt           %global-atts;  class CDATA "+ topic/dt pr-d/pt " >
-<!ATTLIST  repsep       %global-atts;  class CDATA "+ topic/ph pr-d/repsep ">
-<!ATTLIST  sep          %global-atts;  class CDATA "+ topic/ph pr-d/sep ">
-<!ATTLIST  synblk       %global-atts;  class CDATA "+ topic/figgroup pr-d/synblk ">
-<!ATTLIST  synnote      %global-atts;  class CDATA "+ topic/fn pr-d/synnote ">
-<!ATTLIST  synnoteref   %global-atts;  class CDATA "+ topic/xref pr-d/synnoteref ">
-<!ATTLIST  synph        %global-atts;  class CDATA "+ topic/ph pr-d/synph ">
-<!ATTLIST  syntaxdiagram %global-atts;  class CDATA "+ topic/fig pr-d/syntaxdiagram ">
-<!ATTLIST  var          %global-atts;  class CDATA "+ topic/ph pr-d/var ">
+<!ATTLIST  apiname      class CDATA "+ topic/keyword pr-d/apiname ">
+<!ATTLIST  codeblock    class CDATA "+ topic/pre pr-d/codeblock ">
+<!ATTLIST  codeph       class CDATA "+ topic/ph pr-d/codeph ">
+<!ATTLIST  coderef      class CDATA "+ topic/xref pr-d/coderef ">
+<!ATTLIST  delim        class CDATA "+ topic/ph pr-d/delim ">
+<!ATTLIST  fragment     class CDATA "+ topic/figgroup pr-d/fragment ">
+<!ATTLIST  fragref      class CDATA "+ topic/xref pr-d/fragref ">
+<!ATTLIST  groupchoice  class CDATA "+ topic/figgroup pr-d/groupchoice ">
+<!ATTLIST  groupcomp    class CDATA "+ topic/figgroup pr-d/groupcomp ">
+<!ATTLIST  groupseq     class CDATA "+ topic/figgroup pr-d/groupseq ">
+<!ATTLIST  kwd          class CDATA "+ topic/keyword pr-d/kwd ">
+<!ATTLIST  oper         class CDATA "+ topic/ph pr-d/oper ">
+<!ATTLIST  option       class CDATA "+ topic/keyword pr-d/option ">
+<!ATTLIST  parml        class CDATA "+ topic/dl pr-d/parml ">
+<!ATTLIST  parmname     class CDATA "+ topic/keyword pr-d/parmname ">
+<!ATTLIST  pd           class CDATA "+ topic/dd pr-d/pd " >
+<!ATTLIST  plentry      class CDATA "+ topic/dlentry pr-d/plentry ">
+<!ATTLIST  pt           class CDATA "+ topic/dt pr-d/pt " >
+<!ATTLIST  repsep       class CDATA "+ topic/ph pr-d/repsep ">
+<!ATTLIST  sep          class CDATA "+ topic/ph pr-d/sep ">
+<!ATTLIST  synblk       class CDATA "+ topic/figgroup pr-d/synblk ">
+<!ATTLIST  synnote      class CDATA "+ topic/fn pr-d/synnote ">
+<!ATTLIST  synnoteref   class CDATA "+ topic/xref pr-d/synnoteref ">
+<!ATTLIST  synph        class CDATA "+ topic/ph pr-d/synph ">
+<!ATTLIST  syntaxdiagram class CDATA "+ topic/fig pr-d/syntaxdiagram ">
+<!ATTLIST  var          class CDATA "+ topic/ph pr-d/var ">
 
 <!-- ================== End of DITA Programming Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/reference.dtd
+++ b/doctypes/dtd/technicalContent/dtd/reference.dtd
@@ -86,11 +86,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -152,9 +147,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -232,7 +224,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &mathml-d-att;
                            &pr-d-att;
@@ -286,11 +277,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/reference.dtd
+++ b/doctypes/dtd/technicalContent/dtd/reference.dtd
@@ -135,10 +135,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -199,7 +219,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -220,7 +244,11 @@
 <!ENTITY included-domains
                           "&reference-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/reference.mod
+++ b/doctypes/dtd/technicalContent/dtd/reference.mod
@@ -298,19 +298,19 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  reference    %global-atts;  class CDATA "- topic/topic       reference/reference ">
-<!ATTLIST  refbody      %global-atts;  class CDATA "- topic/body        reference/refbody ">
-<!ATTLIST  refbodydiv   %global-atts;  class CDATA "- topic/bodydiv     reference/refbodydiv ">
-<!ATTLIST  refsyn       %global-atts;  class CDATA "- topic/section     reference/refsyn ">
-<!ATTLIST  properties   %global-atts;  class CDATA "- topic/simpletable reference/properties ">
-<!ATTLIST  property     %global-atts;  class CDATA "- topic/strow       reference/property ">
-<!ATTLIST  proptype     %global-atts;  class CDATA "- topic/stentry     reference/proptype ">
-<!ATTLIST  propvalue    %global-atts;  class CDATA "- topic/stentry     reference/propvalue ">
-<!ATTLIST  propdesc     %global-atts;  class CDATA "- topic/stentry     reference/propdesc ">
-<!ATTLIST  prophead     %global-atts;  class CDATA "- topic/sthead      reference/prophead ">
-<!ATTLIST  proptypehd   %global-atts;  class CDATA "- topic/stentry     reference/proptypehd ">
-<!ATTLIST  propvaluehd  %global-atts;  class CDATA "- topic/stentry     reference/propvaluehd ">
-<!ATTLIST  propdeschd   %global-atts;  class CDATA "- topic/stentry     reference/propdeschd ">
+<!ATTLIST  reference    class CDATA "- topic/topic       reference/reference ">
+<!ATTLIST  refbody      class CDATA "- topic/body        reference/refbody ">
+<!ATTLIST  refbodydiv   class CDATA "- topic/bodydiv     reference/refbodydiv ">
+<!ATTLIST  refsyn       class CDATA "- topic/section     reference/refsyn ">
+<!ATTLIST  properties   class CDATA "- topic/simpletable reference/properties ">
+<!ATTLIST  property     class CDATA "- topic/strow       reference/property ">
+<!ATTLIST  proptype     class CDATA "- topic/stentry     reference/proptype ">
+<!ATTLIST  propvalue    class CDATA "- topic/stentry     reference/propvalue ">
+<!ATTLIST  propdesc     class CDATA "- topic/stentry     reference/propdesc ">
+<!ATTLIST  prophead     class CDATA "- topic/sthead      reference/prophead ">
+<!ATTLIST  proptypehd   class CDATA "- topic/stentry     reference/proptypehd ">
+<!ATTLIST  propvaluehd  class CDATA "- topic/stentry     reference/propvaluehd ">
+<!ATTLIST  propdeschd   class CDATA "- topic/stentry     reference/propdeschd ">
 
 <!-- ================== End of DITA Reference ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/reference.mod
+++ b/doctypes/dtd/technicalContent/dtd/reference.mod
@@ -138,10 +138,7 @@
                          %table;)*"
 >
 <!ENTITY % refbodydiv.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  refbodydiv %refbodydiv.content;>
 <!ATTLIST  refbodydiv %refbodydiv.attributes;>
@@ -155,10 +152,7 @@
               "spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  refsyn %refsyn.content;>
 <!ATTLIST  refsyn %refsyn.attributes;>
@@ -183,10 +177,7 @@
                           CDATA
                                     #IMPLIED
                %display-atts;
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  properties %properties.content;>
 <!ATTLIST  properties %properties.attributes;>
@@ -199,10 +190,7 @@
                          (%propdeschd;)?)"
 >
 <!ENTITY % prophead.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  prophead %prophead.content;>
 <!ATTLIST  prophead %prophead.attributes;>
@@ -216,10 +204,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  proptypehd %proptypehd.content;>
 <!ATTLIST  proptypehd %proptypehd.attributes;>
@@ -233,10 +218,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  propvaluehd %propvaluehd.content;>
 <!ATTLIST  propvaluehd %propvaluehd.attributes;>
@@ -250,10 +232,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  propdeschd %propdeschd.content;>
 <!ATTLIST  propdeschd %propdeschd.attributes;>
@@ -266,10 +245,7 @@
                          (%propdesc;)?)"
 >
 <!ENTITY % property.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  property %property.content;>
 <!ATTLIST  property %property.attributes;>
@@ -283,10 +259,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  proptype %proptype.content;>
 <!ATTLIST  proptype %proptype.attributes;>
@@ -300,10 +273,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  propvalue %propvalue.content;>
 <!ATTLIST  propvalue %propvalue.attributes;>
@@ -317,10 +287,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  propdesc %propdesc.content;>
 <!ATTLIST  propdesc %propdesc.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
@@ -49,9 +49,6 @@
               "%univ-atts;
                datatype
                           CDATA
-                                    #IMPLIED
-               outputclass
-                          CDATA
                                     #IMPLIED"
 >
 <!--                    LONG NAME: Change History List             -->

--- a/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
@@ -219,17 +219,17 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  change-historylist %global-atts;  class CDATA "+ topic/metadata relmgmt-d/change-historylist ">
-<!ATTLIST  change-item  %global-atts;  class CDATA "+ topic/data relmgmt-d/change-item ">
-<!ATTLIST  change-person %global-atts;  class CDATA "+ topic/data relmgmt-d/change-person ">
-<!ATTLIST  change-organization %global-atts;  class CDATA "+ topic/data relmgmt-d/change-organization ">
-<!ATTLIST  change-revisionid %global-atts;  class CDATA "+ topic/data relmgmt-d/change-revisionid ">
-<!ATTLIST  change-request-reference %global-atts;  class CDATA "+ topic/data relmgmt-d/change-request-reference ">
-<!ATTLIST  change-request-system %global-atts;  class CDATA "+ topic/data relmgmt-d/change-request-system ">
-<!ATTLIST  change-request-id %global-atts;  class CDATA "+ topic/data relmgmt-d/change-request-id ">
-<!ATTLIST  change-started %global-atts;  class CDATA "+ topic/data relmgmt-d/change-started ">
-<!ATTLIST  change-completed %global-atts;  class CDATA "+ topic/data relmgmt-d/change-completed ">
-<!ATTLIST  change-summary %global-atts;  class CDATA "+ topic/data relmgmt-d/change-summary ">
+<!ATTLIST  change-historylist class CDATA "+ topic/metadata relmgmt-d/change-historylist ">
+<!ATTLIST  change-item  class CDATA "+ topic/data relmgmt-d/change-item ">
+<!ATTLIST  change-person class CDATA "+ topic/data relmgmt-d/change-person ">
+<!ATTLIST  change-organization class CDATA "+ topic/data relmgmt-d/change-organization ">
+<!ATTLIST  change-revisionid class CDATA "+ topic/data relmgmt-d/change-revisionid ">
+<!ATTLIST  change-request-reference class CDATA "+ topic/data relmgmt-d/change-request-reference ">
+<!ATTLIST  change-request-system class CDATA "+ topic/data relmgmt-d/change-request-system ">
+<!ATTLIST  change-request-id class CDATA "+ topic/data relmgmt-d/change-request-id ">
+<!ATTLIST  change-started class CDATA "+ topic/data relmgmt-d/change-started ">
+<!ATTLIST  change-completed class CDATA "+ topic/data relmgmt-d/change-completed ">
+<!ATTLIST  change-summary class CDATA "+ topic/data relmgmt-d/change-summary ">
 
 <!-- ================== End of DITA Release Management Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/softwareDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/softwareDomain.mod
@@ -168,14 +168,14 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  cmdname      %global-atts;  class CDATA "+ topic/keyword sw-d/cmdname ">
-<!ATTLIST  filepath     %global-atts;  class CDATA "+ topic/ph sw-d/filepath ">
-<!ATTLIST  msgblock     %global-atts;  class CDATA "+ topic/pre sw-d/msgblock ">
-<!ATTLIST  msgnum       %global-atts;  class CDATA "+ topic/keyword sw-d/msgnum ">
-<!ATTLIST  msgph        %global-atts;  class CDATA "+ topic/ph sw-d/msgph ">
-<!ATTLIST  systemoutput %global-atts;  class CDATA "+ topic/ph sw-d/systemoutput ">
-<!ATTLIST  userinput    %global-atts;  class CDATA "+ topic/ph sw-d/userinput ">
-<!ATTLIST  varname      %global-atts;  class CDATA "+ topic/keyword sw-d/varname ">
+<!ATTLIST  cmdname      class CDATA "+ topic/keyword sw-d/cmdname ">
+<!ATTLIST  filepath     class CDATA "+ topic/ph sw-d/filepath ">
+<!ATTLIST  msgblock     class CDATA "+ topic/pre sw-d/msgblock ">
+<!ATTLIST  msgnum       class CDATA "+ topic/keyword sw-d/msgnum ">
+<!ATTLIST  msgph        class CDATA "+ topic/ph sw-d/msgph ">
+<!ATTLIST  systemoutput class CDATA "+ topic/ph sw-d/systemoutput ">
+<!ATTLIST  userinput    class CDATA "+ topic/ph sw-d/userinput ">
+<!ATTLIST  varname      class CDATA "+ topic/keyword sw-d/varname ">
 
 <!-- ================== End of DITA Software Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/softwareDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/softwareDomain.mod
@@ -59,10 +59,7 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % msgph.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  msgph %msgph.content;>
 <!ATTLIST  msgph %msgph.attributes;>
@@ -79,9 +76,6 @@
                           CDATA
                                     #IMPLIED
                %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED
                xml:space
                           (preserve)
                                     #FIXED 
@@ -100,10 +94,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  msgnum %msgnum.content;>
 <!ATTLIST  msgnum %msgnum.attributes;>
@@ -118,10 +109,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  cmdname %cmdname.content;>
 <!ATTLIST  cmdname %cmdname.attributes;>
@@ -136,10 +124,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  varname %varname.content;>
 <!ATTLIST  varname %varname.attributes;>
@@ -150,10 +135,7 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % filepath.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  filepath %filepath.content;>
 <!ATTLIST  filepath %filepath.attributes;>
@@ -164,10 +146,7 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % userinput.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  userinput %userinput.content;>
 <!ATTLIST  userinput %userinput.attributes;>
@@ -178,10 +157,7 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % systemoutput.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  systemoutput %systemoutput.content;>
 <!ATTLIST  systemoutput %systemoutput.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/svgDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/svgDomain.mod
@@ -30,10 +30,7 @@
                          %data-about;)*"
 >
 <!ENTITY % svg-container.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  svg-container %svg-container.content;>
 <!ATTLIST  svg-container %svg-container.attributes;>
@@ -53,10 +50,7 @@
                format
                           CDATA
                                     'svg'
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  svgref %svgref.content;>
 <!ATTLIST  svgref %svgref.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/svgDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/svgDomain.mod
@@ -61,8 +61,8 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  svg-container %global-atts;  class CDATA "+ topic/foreign svg-d/svg-container ">
-<!ATTLIST  svgref       %global-atts;  class CDATA "+ topic/xref svg-d/svgref ">
+<!ATTLIST  svg-container class CDATA "+ topic/foreign svg-d/svg-container ">
+<!ATTLIST  svgref       class CDATA "+ topic/xref svg-d/svgref ">
 
 <!-- ================== End of DITA SVG Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/task.dtd
+++ b/doctypes/dtd/technicalContent/dtd/task.dtd
@@ -84,11 +84,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -150,9 +145,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -230,7 +222,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &mathml-d-att;
                            &pr-d-att;
@@ -290,11 +281,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/task.dtd
+++ b/doctypes/dtd/technicalContent/dtd/task.dtd
@@ -133,10 +133,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -197,7 +217,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -218,7 +242,11 @@
 <!ENTITY included-domains
                           "&task-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/task.mod
+++ b/doctypes/dtd/technicalContent/dtd/task.mod
@@ -547,35 +547,35 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  task         %global-atts;  class CDATA "- topic/topic task/task ">
-<!ATTLIST  taskbody     %global-atts;  class CDATA "- topic/body task/taskbody ">
-<!ATTLIST  steps        %global-atts;  class CDATA "- topic/ol task/steps ">
-<!ATTLIST  steps-unordered %global-atts;  class CDATA "- topic/ul task/steps-unordered ">
-<!ATTLIST  stepsection  %global-atts;  class CDATA "- topic/li task/stepsection ">
-<!ATTLIST  step         %global-atts;  class CDATA "- topic/li task/step ">
-<!ATTLIST  cmd          %global-atts;  class CDATA "- topic/ph task/cmd ">
-<!ATTLIST  substeps     %global-atts;  class CDATA "- topic/ol task/substeps ">
-<!ATTLIST  substep      %global-atts;  class CDATA "- topic/li task/substep ">
-<!ATTLIST  tutorialinfo %global-atts;  class CDATA "- topic/itemgroup task/tutorialinfo ">
-<!ATTLIST  info         %global-atts;  class CDATA "- topic/itemgroup task/info ">
-<!ATTLIST  stepxmp      %global-atts;  class CDATA "- topic/itemgroup task/stepxmp ">
-<!ATTLIST  stepresult   %global-atts;  class CDATA "- topic/itemgroup task/stepresult ">
-<!ATTLIST  steptroubleshooting %global-atts;  class CDATA "- topic/itemgroup task/steptroubleshooting ">
-<!ATTLIST  choices      %global-atts;  class CDATA "- topic/ul task/choices ">
-<!ATTLIST  choice       %global-atts;  class CDATA "- topic/li task/choice ">
-<!ATTLIST  result       %global-atts;  class CDATA "- topic/section task/result ">
-<!ATTLIST  tasktroubleshooting %global-atts;  class CDATA "- topic/section task/tasktroubleshooting ">
-<!ATTLIST  prereq       %global-atts;  class CDATA "- topic/section task/prereq ">
-<!ATTLIST  postreq      %global-atts;  class CDATA "- topic/section task/postreq ">
-<!ATTLIST  context      %global-atts;  class CDATA "- topic/section task/context ">
-<!ATTLIST  steps-informal %global-atts;  class CDATA "- topic/section task/steps-informal ">
-<!ATTLIST  choicetable  %global-atts;  class CDATA "- topic/simpletable task/choicetable ">
-<!ATTLIST  chhead       %global-atts;  class CDATA "- topic/sthead task/chhead ">
-<!ATTLIST  chrow        %global-atts;  class CDATA "- topic/strow task/chrow ">
-<!ATTLIST  choptionhd   %global-atts;  class CDATA "- topic/stentry task/choptionhd ">
-<!ATTLIST  chdeschd     %global-atts;  class CDATA "- topic/stentry task/chdeschd ">
-<!ATTLIST  choption     %global-atts;  class CDATA "- topic/stentry task/choption ">
-<!ATTLIST  chdesc       %global-atts;  class CDATA "- topic/stentry task/chdesc ">
+<!ATTLIST  task         class CDATA "- topic/topic task/task ">
+<!ATTLIST  taskbody     class CDATA "- topic/body task/taskbody ">
+<!ATTLIST  steps        class CDATA "- topic/ol task/steps ">
+<!ATTLIST  steps-unordered class CDATA "- topic/ul task/steps-unordered ">
+<!ATTLIST  stepsection  class CDATA "- topic/li task/stepsection ">
+<!ATTLIST  step         class CDATA "- topic/li task/step ">
+<!ATTLIST  cmd          class CDATA "- topic/ph task/cmd ">
+<!ATTLIST  substeps     class CDATA "- topic/ol task/substeps ">
+<!ATTLIST  substep      class CDATA "- topic/li task/substep ">
+<!ATTLIST  tutorialinfo class CDATA "- topic/itemgroup task/tutorialinfo ">
+<!ATTLIST  info         class CDATA "- topic/itemgroup task/info ">
+<!ATTLIST  stepxmp      class CDATA "- topic/itemgroup task/stepxmp ">
+<!ATTLIST  stepresult   class CDATA "- topic/itemgroup task/stepresult ">
+<!ATTLIST  steptroubleshooting class CDATA "- topic/itemgroup task/steptroubleshooting ">
+<!ATTLIST  choices      class CDATA "- topic/ul task/choices ">
+<!ATTLIST  choice       class CDATA "- topic/li task/choice ">
+<!ATTLIST  result       class CDATA "- topic/section task/result ">
+<!ATTLIST  tasktroubleshooting class CDATA "- topic/section task/tasktroubleshooting ">
+<!ATTLIST  prereq       class CDATA "- topic/section task/prereq ">
+<!ATTLIST  postreq      class CDATA "- topic/section task/postreq ">
+<!ATTLIST  context      class CDATA "- topic/section task/context ">
+<!ATTLIST  steps-informal class CDATA "- topic/section task/steps-informal ">
+<!ATTLIST  choicetable  class CDATA "- topic/simpletable task/choicetable ">
+<!ATTLIST  chhead       class CDATA "- topic/sthead task/chhead ">
+<!ATTLIST  chrow        class CDATA "- topic/strow task/chrow ">
+<!ATTLIST  choptionhd   class CDATA "- topic/stentry task/choptionhd ">
+<!ATTLIST  chdeschd     class CDATA "- topic/stentry task/chdeschd ">
+<!ATTLIST  choption     class CDATA "- topic/stentry task/choption ">
+<!ATTLIST  chdesc       class CDATA "- topic/stentry task/chdesc ">
 
 <!-- ================== End of DITA Task ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/task.mod
+++ b/doctypes/dtd/technicalContent/dtd/task.mod
@@ -104,6 +104,9 @@
                           CDATA
                                     #IMPLIED
                %base-attribute-extensions;
+               outputclass
+                          CDATA
+                                    #IMPLIED
                rev
                           CDATA
                                     #IMPLIED
@@ -180,10 +183,7 @@
                        "(%section.notitle.cnt;)*"
 >
 <!ENTITY % prereq.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  prereq %prereq.content;>
 <!ATTLIST  prereq %prereq.attributes;>
@@ -194,10 +194,7 @@
                        "(%section.notitle.cnt;)*"
 >
 <!ENTITY % context.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  context %context.content;>
 <!ATTLIST  context %context.attributes;>
@@ -208,10 +205,7 @@
                        "(%section.notitle.cnt;)*"
 >
 <!ENTITY % steps-informal.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  steps-informal %steps-informal.content;>
 <!ATTLIST  steps-informal %steps-informal.attributes;>
@@ -225,10 +219,7 @@
                           (%step;))+)"
 >
 <!ENTITY % steps.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  steps %steps.content;>
 <!ATTLIST  steps %steps.attributes;>
@@ -242,10 +233,7 @@
                           (%step;))+)"
 >
 <!ENTITY % steps-unordered.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  steps-unordered %steps-unordered.content;>
 <!ATTLIST  steps-unordered %steps-unordered.attributes;>
@@ -256,10 +244,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % stepsection.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  stepsection %stepsection.content;>
 <!ATTLIST  stepsection %stepsection.attributes;>
@@ -285,10 +270,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance-task;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance-task;"
 >
 <!ELEMENT  step %step.content;>
 <!ATTLIST  step %step.attributes;>
@@ -302,10 +284,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  cmd %cmd.content;>
 <!ATTLIST  cmd %cmd.attributes;>
@@ -316,10 +295,7 @@
                        "(%itemgroup.cnt;)*"
 >
 <!ENTITY % info.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  info %info.content;>
 <!ATTLIST  info %info.attributes;>
@@ -332,10 +308,7 @@
                          (%substep;)+)"
 >
 <!ENTITY % substeps.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  substeps %substeps.content;>
 <!ATTLIST  substeps %substeps.attributes;>
@@ -357,10 +330,7 @@
                            required |
                            -dita-use-conref-target)
                                     #IMPLIED
-               %univ-atts-no-importance-task;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts-no-importance-task;"
 >
 <!ELEMENT  substep %substep.content;>
 <!ATTLIST  substep %substep.attributes;>
@@ -371,10 +341,7 @@
                        "(%itemgroup.cnt;)*"
 >
 <!ENTITY % tutorialinfo.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  tutorialinfo %tutorialinfo.content;>
 <!ATTLIST  tutorialinfo %tutorialinfo.attributes;>
@@ -385,10 +352,7 @@
                        "(%itemgroup.cnt;)*"
 >
 <!ENTITY % stepxmp.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  stepxmp %stepxmp.content;>
 <!ATTLIST  stepxmp %stepxmp.attributes;>
@@ -401,10 +365,7 @@
                          (%choice;)+)"
 >
 <!ENTITY % choices.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  choices %choices.content;>
 <!ATTLIST  choices %choices.attributes;>
@@ -415,10 +376,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % choice.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  choice %choice.content;>
 <!ATTLIST  choice %choice.attributes;>
@@ -443,10 +401,7 @@
                           CDATA
                                     #IMPLIED
                %display-atts;
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  choicetable %choicetable.content;>
 <!ATTLIST  choicetable %choicetable.attributes;>
@@ -458,10 +413,7 @@
                          (%chdeschd;))"
 >
 <!ENTITY % chhead.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  chhead %chhead.content;>
 <!ATTLIST  chhead %chhead.attributes;>
@@ -475,10 +427,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  choptionhd %choptionhd.content;>
 <!ATTLIST  choptionhd %choptionhd.attributes;>
@@ -492,10 +441,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  chdeschd %chdeschd.content;>
 <!ATTLIST  chdeschd %chdeschd.attributes;>
@@ -507,10 +453,7 @@
                          (%chdesc;))"
 >
 <!ENTITY % chrow.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  chrow %chrow.content;>
 <!ATTLIST  chrow %chrow.attributes;>
@@ -524,10 +467,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  choption %choption.content;>
 <!ATTLIST  choption %choption.attributes;>
@@ -541,10 +481,7 @@
               "specentry
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  chdesc %chdesc.content;>
 <!ATTLIST  chdesc %chdesc.attributes;>
@@ -555,10 +492,7 @@
                        "(%itemgroup.cnt;)*"
 >
 <!ENTITY % stepresult.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  stepresult %stepresult.content;>
 <!ATTLIST  stepresult %stepresult.attributes;>
@@ -569,10 +503,7 @@
                        "(%itemgroup.cnt;)*"
 >
 <!ENTITY % steptroubleshooting.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  steptroubleshooting %steptroubleshooting.content;>
 <!ATTLIST  steptroubleshooting %steptroubleshooting.attributes;>
@@ -583,10 +514,7 @@
                        "(%section.notitle.cnt;)*"
 >
 <!ENTITY % tasktroubleshooting.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  tasktroubleshooting %tasktroubleshooting.content;>
 <!ATTLIST  tasktroubleshooting %tasktroubleshooting.attributes;>
@@ -597,10 +525,7 @@
                        "(%section.notitle.cnt;)*"
 >
 <!ENTITY % result.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  result %result.content;>
 <!ATTLIST  result %result.attributes;>
@@ -611,10 +536,7 @@
                        "(%section.notitle.cnt;)*"
 >
 <!ENTITY % postreq.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  postreq %postreq.content;>
 <!ATTLIST  postreq %postreq.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/taskreqDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/taskreqDomain.mod
@@ -76,10 +76,7 @@
                          (%safety;)?)"
 >
 <!ENTITY % prelreqs.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  prelreqs %prelreqs.content;>
 <!ATTLIST  prelreqs %prelreqs.attributes;>
@@ -90,10 +87,7 @@
                        "(%reqconds;)"
 >
 <!ENTITY % closereqs.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  closereqs %closereqs.content;>
 <!ATTLIST  closereqs %closereqs.attributes;>
@@ -108,10 +102,7 @@
                            %reqcontp;)+))"
 >
 <!ENTITY % reqconds.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  reqconds %reqconds.content;>
 <!ATTLIST  reqconds %reqconds.attributes;>
@@ -122,10 +113,7 @@
                        "EMPTY"
 >
 <!ENTITY % noconds.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  noconds %noconds.content;>
 <!ATTLIST  noconds %noconds.attributes;>
@@ -136,10 +124,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % reqcond.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  reqcond %reqcond.content;>
 <!ATTLIST  reqcond %reqcond.attributes;>
@@ -150,10 +135,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % reqcontp.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  reqcontp %reqcontp.content;>
 <!ATTLIST  reqcontp %reqcontp.attributes;>
@@ -169,10 +151,7 @@
                            (%esttime;)?)?)+)"
 >
 <!ENTITY % reqpers.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  reqpers %reqpers.content;>
 <!ATTLIST  reqpers %reqpers.attributes;>
@@ -183,10 +162,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % personnel.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  personnel %personnel.content;>
 <!ATTLIST  personnel %personnel.attributes;>
@@ -197,10 +173,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % perscat.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  perscat %perscat.content;>
 <!ATTLIST  perscat %perscat.attributes;>
@@ -211,10 +184,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % perskill.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  perskill %perskill.content;>
 <!ATTLIST  perskill %perskill.attributes;>
@@ -225,10 +195,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % esttime.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  esttime %esttime.content;>
 <!ATTLIST  esttime %esttime.attributes;>
@@ -240,10 +207,7 @@
                          %supeqli;)"
 >
 <!ENTITY % supequip.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  supequip %supequip.content;>
 <!ATTLIST  supequip %supequip.attributes;>
@@ -275,10 +239,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  supeqli %supeqli.content;>
 <!ATTLIST  supeqli %supeqli.attributes;>
@@ -289,10 +250,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % supequi.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  supequi %supequi.content;>
 <!ATTLIST  supequi %supequi.attributes;>
@@ -304,10 +262,7 @@
                          %supplyli;)"
 >
 <!ENTITY % supplies.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  supplies %supplies.content;>
 <!ATTLIST  supplies %supplies.attributes;>
@@ -339,10 +294,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  supplyli %supplyli.content;>
 <!ATTLIST  supplyli %supplyli.attributes;>
@@ -353,10 +305,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % supply.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  supply %supply.content;>
 <!ATTLIST  supply %supply.attributes;>
@@ -368,10 +317,7 @@
                          %sparesli;)"
 >
 <!ENTITY % spares.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  spares %spares.content;>
 <!ATTLIST  spares %spares.attributes;>
@@ -403,10 +349,7 @@
                spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  sparesli %sparesli.content;>
 <!ATTLIST  sparesli %sparesli.attributes;>
@@ -417,10 +360,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % spare.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  spare %spare.content;>
 <!ATTLIST  spare %spare.attributes;>
@@ -434,10 +374,7 @@
                           (%safecond;)+))"
 >
 <!ENTITY % safety.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  safety %safety.content;>
 <!ATTLIST  safety %safety.attributes;>
@@ -448,10 +385,7 @@
                        "EMPTY"
 >
 <!ENTITY % nosafety.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  nosafety %nosafety.content;>
 <!ATTLIST  nosafety %nosafety.attributes;>
@@ -462,10 +396,7 @@
                        "(%listitem.cnt;)*"
 >
 <!ENTITY % safecond.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  safecond %safecond.content;>
 <!ATTLIST  safecond %safecond.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/taskreqDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/taskreqDomain.mod
@@ -407,32 +407,32 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  prelreqs     %global-atts;  class CDATA "+ topic/section task/prereq taskreq-d/prelreqs ">
-<!ATTLIST  closereqs    %global-atts;  class CDATA "+ topic/section task/postreq taskreq-d/closereqs ">
-<!ATTLIST  reqconds     %global-atts;  class CDATA "+ topic/ul task/ul taskreq-d/reqconds ">
-<!ATTLIST  noconds      %global-atts;  class CDATA "+ topic/li task/li taskreq-d/noconds ">
-<!ATTLIST  reqcond      %global-atts;  class CDATA "+ topic/li task/li taskreq-d/reqcond ">
-<!ATTLIST  reqcontp     %global-atts;  class CDATA "+ topic/li task/li taskreq-d/reqcontp ">
-<!ATTLIST  reqpers      %global-atts;  class CDATA "+ topic/ul task/ul taskreq-d/reqpers ">
-<!ATTLIST  personnel    %global-atts;  class CDATA "+ topic/li task/li taskreq-d/personnel ">
-<!ATTLIST  perscat      %global-atts;  class CDATA "+ topic/li task/li taskreq-d/perscat ">
-<!ATTLIST  perskill     %global-atts;  class CDATA "+ topic/li task/li taskreq-d/perskill ">
-<!ATTLIST  esttime      %global-atts;  class CDATA "+ topic/li task/li taskreq-d/esttime ">
-<!ATTLIST  supequip     %global-atts;  class CDATA "+ topic/p task/p taskreq-d/supequip ">
-<!ATTLIST  nosupeq      %global-atts;  class CDATA "+ topic/data task/data taskreq-d/nosupeq ">
-<!ATTLIST  supeqli      %global-atts;  class CDATA "+ topic/ul task/ul taskreq-d/supeqli ">
-<!ATTLIST  supequi      %global-atts;  class CDATA "+ topic/li task/li taskreq-d/supequi ">
-<!ATTLIST  supplies     %global-atts;  class CDATA "+ topic/p task/p taskreq-d/supplies ">
-<!ATTLIST  nosupply     %global-atts;  class CDATA "+ topic/data task/data taskreq-d/nosupply ">
-<!ATTLIST  supplyli     %global-atts;  class CDATA "+ topic/ul task/ul taskreq-d/supplyli ">
-<!ATTLIST  supply       %global-atts;  class CDATA "+ topic/li task/li taskreq-d/supply ">
-<!ATTLIST  spares       %global-atts;  class CDATA "+ topic/p task/p taskreq-d/spares ">
-<!ATTLIST  nospares     %global-atts;  class CDATA "+ topic/data task/data taskreq-d/nospares ">
-<!ATTLIST  sparesli     %global-atts;  class CDATA "+ topic/ul task/ul taskreq-d/sparesli ">
-<!ATTLIST  spare        %global-atts;  class CDATA "+ topic/li task/li taskreq-d/spare ">
-<!ATTLIST  safety       %global-atts;  class CDATA "+ topic/ol task/ol taskreq-d/safety ">
-<!ATTLIST  nosafety     %global-atts;  class CDATA "+ topic/li task/li taskreq-d/nosafety ">
-<!ATTLIST  safecond     %global-atts;  class CDATA "+ topic/li task/li taskreq-d/safecond ">
+<!ATTLIST  prelreqs     class CDATA "+ topic/section task/prereq taskreq-d/prelreqs ">
+<!ATTLIST  closereqs    class CDATA "+ topic/section task/postreq taskreq-d/closereqs ">
+<!ATTLIST  reqconds     class CDATA "+ topic/ul task/ul taskreq-d/reqconds ">
+<!ATTLIST  noconds      class CDATA "+ topic/li task/li taskreq-d/noconds ">
+<!ATTLIST  reqcond      class CDATA "+ topic/li task/li taskreq-d/reqcond ">
+<!ATTLIST  reqcontp     class CDATA "+ topic/li task/li taskreq-d/reqcontp ">
+<!ATTLIST  reqpers      class CDATA "+ topic/ul task/ul taskreq-d/reqpers ">
+<!ATTLIST  personnel    class CDATA "+ topic/li task/li taskreq-d/personnel ">
+<!ATTLIST  perscat      class CDATA "+ topic/li task/li taskreq-d/perscat ">
+<!ATTLIST  perskill     class CDATA "+ topic/li task/li taskreq-d/perskill ">
+<!ATTLIST  esttime      class CDATA "+ topic/li task/li taskreq-d/esttime ">
+<!ATTLIST  supequip     class CDATA "+ topic/p task/p taskreq-d/supequip ">
+<!ATTLIST  nosupeq      class CDATA "+ topic/data task/data taskreq-d/nosupeq ">
+<!ATTLIST  supeqli      class CDATA "+ topic/ul task/ul taskreq-d/supeqli ">
+<!ATTLIST  supequi      class CDATA "+ topic/li task/li taskreq-d/supequi ">
+<!ATTLIST  supplies     class CDATA "+ topic/p task/p taskreq-d/supplies ">
+<!ATTLIST  nosupply     class CDATA "+ topic/data task/data taskreq-d/nosupply ">
+<!ATTLIST  supplyli     class CDATA "+ topic/ul task/ul taskreq-d/supplyli ">
+<!ATTLIST  supply       class CDATA "+ topic/li task/li taskreq-d/supply ">
+<!ATTLIST  spares       class CDATA "+ topic/p task/p taskreq-d/spares ">
+<!ATTLIST  nospares     class CDATA "+ topic/data task/data taskreq-d/nospares ">
+<!ATTLIST  sparesli     class CDATA "+ topic/ul task/ul taskreq-d/sparesli ">
+<!ATTLIST  spare        class CDATA "+ topic/li task/li taskreq-d/spare ">
+<!ATTLIST  safety       class CDATA "+ topic/ol task/ol taskreq-d/safety ">
+<!ATTLIST  nosafety     class CDATA "+ topic/li task/li taskreq-d/nosafety ">
+<!ATTLIST  safecond     class CDATA "+ topic/li task/li taskreq-d/safecond ">
 
 <!-- ================== End of DITA Task Requirements Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/topic.dtd
+++ b/doctypes/dtd/technicalContent/dtd/topic.dtd
@@ -126,10 +126,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -190,7 +210,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -210,7 +234,11 @@
 
 <!ENTITY included-domains
                           "&abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/topic.dtd
+++ b/doctypes/dtd/technicalContent/dtd/topic.dtd
@@ -77,11 +77,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -143,9 +138,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -222,7 +214,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &mathml-d-att;
                            &pr-d-att;
@@ -271,11 +262,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
+++ b/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
@@ -81,11 +81,6 @@
          "../../base/dtd/highlightDomain.ent"
 >%hi-d-dec;
 
-<!ENTITY % indexing-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.ent"
->%indexing-d-dec;
-
 <!ENTITY % markup-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Markup Domain//EN"
          "markupDomain.ent"
@@ -147,9 +142,6 @@
                         the name of the domain(s) in which the
                         extension was declared                     -->
 
-<!ENTITY % index-base   "index-base |
-                         %indexing-d-index-base;
-                        ">
 <!ENTITY % note         "note |
                          %hazard-d-note;
                         ">
@@ -231,7 +223,6 @@
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;
-                           &indexing-d-att;
                            &markup-d-att;
                            &mathml-d-att;
                            &pr-d-att;
@@ -296,11 +287,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Highlight Domain//EN"
          "../../base/dtd/highlightDomain.mod"
 >%hi-d-def;
-
-<!ENTITY % indexing-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Indexing Domain//EN"
-         "../../base/dtd/indexingDomain.mod"
->%indexing-d-def;
 
 <!ENTITY % markup-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Markup Domain//EN"

--- a/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
+++ b/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
@@ -130,10 +130,30 @@
 <!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
 <!-- ============================================================= -->
 
+<!ENTITY % audienceAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Audience Attribute Domain//EN"
+         "audienceAttDomain.ent"
+>%audienceAtt-d-dec;
+
 <!ENTITY % deliveryTargetAtt-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Delivery Target Attribute Domain//EN"
-         "../../base/dtd/deliveryTargetAttDomain.ent"
+         "deliveryTargetAttDomain.ent"
 >%deliveryTargetAtt-d-dec;
+
+<!ENTITY % platformAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Platform Attribute Domain//EN"
+         "platformAttDomain.ent"
+>%platformAtt-d-dec;
+
+<!ENTITY % productAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Product Attribute Domain//EN"
+         "productAttDomain.ent"
+>%productAtt-d-dec;
+
+<!ENTITY % otherpropsAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Otherprops Attribute Domain//EN"
+         "otherpropsAttDomain.ent"
+>%otherpropsAtt-d-dec;
 
 <!-- ============================================================= -->
 <!--                    DOMAIN EXTENSIONS                          -->
@@ -194,7 +214,11 @@
 <!-- ============================================================= -->
 
 <!ENTITY % props-attribute-extensions
-  "%deliveryTargetAtt-d-attribute;"
+  "%audienceAtt-d-attribute;
+  %deliveryTargetAtt-d-attribute;
+  %platformAtt-d-attribute;
+  %productAtt-d-attribute;
+  %otherpropsAtt-d-attribute;"
 >
 <!ENTITY % base-attribute-extensions
   ""
@@ -219,7 +243,11 @@
                           "&task-att;
                            &troubleshooting-att;
                            &abbrev-d-att;
+                           &audienceAtt-d-att;
                            &deliveryTargetAtt-d-att;
+                           &otherpropsAtt-d-att;
+                           &platformAtt-d-att;
+                           &productAtt-d-att;
                            &equation-d-att;
                            &hazard-d-att;
                            &hi-d-att;

--- a/doctypes/dtd/technicalContent/dtd/troubleshooting.mod
+++ b/doctypes/dtd/technicalContent/dtd/troubleshooting.mod
@@ -118,9 +118,6 @@
               "%univ-atts;
                spectitle
                           CDATA
-                                    #IMPLIED
-               outputclass
-                          CDATA
                                     #IMPLIED"
 >
 <!ELEMENT  cause %cause.content;>
@@ -134,9 +131,6 @@
 <!ENTITY % condition.attributes
               "%univ-atts;
                spectitle
-                          CDATA
-                                    #IMPLIED
-               outputclass
                           CDATA
                                     #IMPLIED"
 >
@@ -156,10 +150,7 @@
               "spectitle
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  remedy %remedy.content;>
 <!ATTLIST  remedy %remedy.attributes;>
@@ -170,10 +161,7 @@
                        "(%para.cnt;)*"
 >
 <!ENTITY % responsibleParty.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  responsibleParty %responsibleParty.content;>
 <!ATTLIST  responsibleParty %responsibleParty.attributes;>
@@ -185,10 +173,7 @@
                          (%remedy;)*)"
 >
 <!ENTITY % troubleSolution.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  troubleSolution %troubleSolution.content;>
 <!ATTLIST  troubleSolution %troubleSolution.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/troubleshooting.mod
+++ b/doctypes/dtd/technicalContent/dtd/troubleshooting.mod
@@ -184,13 +184,13 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  troubleshooting %global-atts;  class CDATA "- topic/topic troubleshooting/troubleshooting ">
-<!ATTLIST  troublebody  %global-atts;  class CDATA "- topic/body troubleshooting/troublebody ">
-<!ATTLIST  troubleSolution %global-atts;  class CDATA "- topic/bodydiv troubleshooting/troubleSolution ">
-<!ATTLIST  cause        %global-atts;  class CDATA "- topic/section troubleshooting/cause ">
-<!ATTLIST  condition    %global-atts;  class CDATA "- topic/section troubleshooting/condition ">
-<!ATTLIST  remedy       %global-atts;  class CDATA "- topic/section troubleshooting/remedy ">
-<!ATTLIST  responsibleParty %global-atts;  class CDATA "- topic/p troubleshooting/responsibleParty ">
+<!ATTLIST  troubleshooting class CDATA "- topic/topic troubleshooting/troubleshooting ">
+<!ATTLIST  troublebody  class CDATA "- topic/body troubleshooting/troublebody ">
+<!ATTLIST  troubleSolution class CDATA "- topic/bodydiv troubleshooting/troubleSolution ">
+<!ATTLIST  cause        class CDATA "- topic/section troubleshooting/cause ">
+<!ATTLIST  condition    class CDATA "- topic/section troubleshooting/condition ">
+<!ATTLIST  remedy       class CDATA "- topic/section troubleshooting/remedy ">
+<!ATTLIST  responsibleParty class CDATA "- topic/p troubleshooting/responsibleParty ">
 
 <!-- ================== End of DITA Troubleshooting Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/uiDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/uiDomain.mod
@@ -138,11 +138,11 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  menucascade  %global-atts;  class CDATA "+ topic/ph ui-d/menucascade ">
-<!ATTLIST  screen       %global-atts;  class CDATA "+ topic/pre ui-d/screen ">
-<!ATTLIST  shortcut     %global-atts;  class CDATA "+ topic/keyword ui-d/shortcut ">
-<!ATTLIST  uicontrol    %global-atts;  class CDATA "+ topic/ph ui-d/uicontrol ">
-<!ATTLIST  wintitle     %global-atts;  class CDATA "+ topic/keyword ui-d/wintitle ">
+<!ATTLIST  menucascade  class CDATA "+ topic/ph ui-d/menucascade ">
+<!ATTLIST  screen       class CDATA "+ topic/pre ui-d/screen ">
+<!ATTLIST  shortcut     class CDATA "+ topic/keyword ui-d/shortcut ">
+<!ATTLIST  uicontrol    class CDATA "+ topic/ph ui-d/uicontrol ">
+<!ATTLIST  wintitle     class CDATA "+ topic/keyword ui-d/wintitle ">
 
 <!-- ================== End of DITA User Interface Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/uiDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/uiDomain.mod
@@ -60,10 +60,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  uicontrol %uicontrol.content;>
 <!ATTLIST  uicontrol %uicontrol.attributes;>
@@ -78,10 +75,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  wintitle %wintitle.content;>
 <!ATTLIST  wintitle %wintitle.attributes;>
@@ -95,10 +89,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  menucascade %menucascade.content;>
 <!ATTLIST  menucascade %menucascade.attributes;>
@@ -113,10 +104,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  shortcut %shortcut.content;>
 <!ATTLIST  shortcut %shortcut.attributes;>
@@ -139,10 +127,7 @@
                           (preserve)
                                     #FIXED 
                                     'preserve'
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  screen %screen.content;>
 <!ATTLIST  screen %screen.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/xmlDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/xmlDomain.mod
@@ -35,10 +35,7 @@
                          %text;)*"
 >
 <!ENTITY % numcharref.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  numcharref %numcharref.content;>
 <!ATTLIST  numcharref %numcharref.attributes;>
@@ -52,10 +49,7 @@
                          %text;)*"
 >
 <!ENTITY % parameterentity.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  parameterentity %parameterentity.content;>
 <!ATTLIST  parameterentity %parameterentity.attributes;>
@@ -69,10 +63,7 @@
                          %text;)*"
 >
 <!ENTITY % textentity.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  textentity %textentity.content;>
 <!ATTLIST  textentity %textentity.attributes;>
@@ -86,10 +77,7 @@
                          %text;)*"
 >
 <!ENTITY % xmlatt.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  xmlatt %xmlatt.content;>
 <!ATTLIST  xmlatt %xmlatt.attributes;>
@@ -103,10 +91,7 @@
                          %text;)*"
 >
 <!ENTITY % xmlelement.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  xmlelement %xmlelement.content;>
 <!ATTLIST  xmlelement %xmlelement.attributes;>
@@ -120,10 +105,7 @@
                          %text;)*"
 >
 <!ENTITY % xmlnsname.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  xmlnsname %xmlnsname.content;>
 <!ATTLIST  xmlnsname %xmlnsname.attributes;>
@@ -137,10 +119,7 @@
                          %text;)*"
 >
 <!ENTITY % xmlpi.attributes
-              "%univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  xmlpi %xmlpi.content;>
 <!ATTLIST  xmlpi %xmlpi.attributes;>

--- a/doctypes/dtd/technicalContent/dtd/xmlDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/xmlDomain.mod
@@ -130,13 +130,13 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  numcharref   %global-atts;  class CDATA "+ topic/keyword markup-d/markupname xml-d/numcharref ">
-<!ATTLIST  parameterentity %global-atts;  class CDATA "+ topic/keyword markup-d/markupname xml-d/parameterentity ">
-<!ATTLIST  textentity   %global-atts;  class CDATA "+ topic/keyword markup-d/markupname xml-d/textentity ">
-<!ATTLIST  xmlatt       %global-atts;  class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlatt ">
-<!ATTLIST  xmlelement   %global-atts;  class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlelement ">
-<!ATTLIST  xmlnsname    %global-atts;  class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlnsname ">
-<!ATTLIST  xmlpi        %global-atts;  class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlpi ">
+<!ATTLIST  numcharref   class CDATA "+ topic/keyword markup-d/markupname xml-d/numcharref ">
+<!ATTLIST  parameterentity class CDATA "+ topic/keyword markup-d/markupname xml-d/parameterentity ">
+<!ATTLIST  textentity   class CDATA "+ topic/keyword markup-d/markupname xml-d/textentity ">
+<!ATTLIST  xmlatt       class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlatt ">
+<!ATTLIST  xmlelement   class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlelement ">
+<!ATTLIST  xmlnsname    class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlnsname ">
+<!ATTLIST  xmlpi        class CDATA "+ topic/keyword markup-d/markupname xml-d/xmlpi ">
 
 <!-- ================== End of DITA XML Construct Domain ==================== -->
  

--- a/doctypes/dtd/xnal/dtd/xnalDomain.mod
+++ b/doctypes/dtd/xnal/dtd/xnalDomain.mod
@@ -456,32 +456,32 @@
 <!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
 <!-- ============================================================= -->
   
-<!ATTLIST  addressdetails %global-atts;  class CDATA "+ topic/ph xnal-d/addressdetails ">
-<!ATTLIST  administrativearea %global-atts;  class CDATA "+ topic/ph xnal-d/administrativearea ">
-<!ATTLIST  authorinformation %global-atts;  class CDATA "+ topic/author xnal-d/authorinformation ">
-<!ATTLIST  contactnumber %global-atts;  class CDATA "+ topic/data xnal-d/contactnumber ">
-<!ATTLIST  contactnumbers %global-atts;  class CDATA "+ topic/data xnal-d/contactnumbers ">
-<!ATTLIST  country      %global-atts;  class CDATA "+ topic/ph xnal-d/country ">
-<!ATTLIST  emailaddress %global-atts;  class CDATA "+ topic/data xnal-d/emailaddress ">
-<!ATTLIST  emailaddresses %global-atts;  class CDATA "+ topic/data xnal-d/emailaddresses ">
-<!ATTLIST  firstname    %global-atts;  class CDATA "+ topic/data xnal-d/firstname ">
-<!ATTLIST  generationidentifier %global-atts;  class CDATA "+ topic/data xnal-d/generationidentifier ">
-<!ATTLIST  honorific    %global-atts;  class CDATA "+ topic/data xnal-d/honorific ">
-<!ATTLIST  lastname     %global-atts;  class CDATA "+ topic/data xnal-d/lastname ">
-<!ATTLIST  locality     %global-atts;  class CDATA "+ topic/ph xnal-d/locality ">
-<!ATTLIST  localityname %global-atts;  class CDATA "+ topic/ph xnal-d/localityname ">
-<!ATTLIST  middlename   %global-atts;  class CDATA "+ topic/data xnal-d/middlename ">
-<!ATTLIST  namedetails  %global-atts;  class CDATA "+ topic/data xnal-d/namedetails ">
-<!ATTLIST  organizationinfo %global-atts;  class CDATA "+ topic/data xnal-d/organizationinfo ">
-<!ATTLIST  organizationname %global-atts;  class CDATA "+ topic/ph xnal-d/organizationname ">
-<!ATTLIST  organizationnamedetails %global-atts;  class CDATA "+ topic/ph xnal-d/organizationnamedetails ">
-<!ATTLIST  otherinfo    %global-atts;  class CDATA "+ topic/data xnal-d/otherinfo ">
-<!ATTLIST  personinfo   %global-atts;  class CDATA "+ topic/data xnal-d/personinfo ">
-<!ATTLIST  personname   %global-atts;  class CDATA "+ topic/data xnal-d/personname ">
-<!ATTLIST  postalcode   %global-atts;  class CDATA "+ topic/ph xnal-d/postalcode ">
-<!ATTLIST  thoroughfare %global-atts;  class CDATA "+ topic/ph xnal-d/thoroughfare ">
-<!ATTLIST  url          %global-atts;  class CDATA "+ topic/data xnal-d/url ">
-<!ATTLIST  urls         %global-atts;  class CDATA "+ topic/data xnal-d/urls ">
+<!ATTLIST  addressdetails class CDATA "+ topic/ph xnal-d/addressdetails ">
+<!ATTLIST  administrativearea class CDATA "+ topic/ph xnal-d/administrativearea ">
+<!ATTLIST  authorinformation class CDATA "+ topic/author xnal-d/authorinformation ">
+<!ATTLIST  contactnumber class CDATA "+ topic/data xnal-d/contactnumber ">
+<!ATTLIST  contactnumbers class CDATA "+ topic/data xnal-d/contactnumbers ">
+<!ATTLIST  country      class CDATA "+ topic/ph xnal-d/country ">
+<!ATTLIST  emailaddress class CDATA "+ topic/data xnal-d/emailaddress ">
+<!ATTLIST  emailaddresses class CDATA "+ topic/data xnal-d/emailaddresses ">
+<!ATTLIST  firstname    class CDATA "+ topic/data xnal-d/firstname ">
+<!ATTLIST  generationidentifier class CDATA "+ topic/data xnal-d/generationidentifier ">
+<!ATTLIST  honorific    class CDATA "+ topic/data xnal-d/honorific ">
+<!ATTLIST  lastname     class CDATA "+ topic/data xnal-d/lastname ">
+<!ATTLIST  locality     class CDATA "+ topic/ph xnal-d/locality ">
+<!ATTLIST  localityname class CDATA "+ topic/ph xnal-d/localityname ">
+<!ATTLIST  middlename   class CDATA "+ topic/data xnal-d/middlename ">
+<!ATTLIST  namedetails  class CDATA "+ topic/data xnal-d/namedetails ">
+<!ATTLIST  organizationinfo class CDATA "+ topic/data xnal-d/organizationinfo ">
+<!ATTLIST  organizationname class CDATA "+ topic/ph xnal-d/organizationname ">
+<!ATTLIST  organizationnamedetails class CDATA "+ topic/ph xnal-d/organizationnamedetails ">
+<!ATTLIST  otherinfo    class CDATA "+ topic/data xnal-d/otherinfo ">
+<!ATTLIST  personinfo   class CDATA "+ topic/data xnal-d/personinfo ">
+<!ATTLIST  personname   class CDATA "+ topic/data xnal-d/personname ">
+<!ATTLIST  postalcode   class CDATA "+ topic/ph xnal-d/postalcode ">
+<!ATTLIST  thoroughfare class CDATA "+ topic/ph xnal-d/thoroughfare ">
+<!ATTLIST  url          class CDATA "+ topic/data xnal-d/url ">
+<!ATTLIST  urls         class CDATA "+ topic/data xnal-d/urls ">
 
 <!-- ================== End of DITA XNAL Domain ==================== -->
  

--- a/doctypes/dtd/xnal/dtd/xnalDomain.mod
+++ b/doctypes/dtd/xnal/dtd/xnalDomain.mod
@@ -134,10 +134,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  organizationnamedetails %organizationnamedetails.content;>
 <!ATTLIST  organizationnamedetails %organizationnamedetails.attributes;>
@@ -151,10 +148,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  organizationname %organizationname.content;>
 <!ATTLIST  organizationname %organizationname.attributes;>
@@ -264,10 +258,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  addressdetails %addressdetails.content;>
 <!ATTLIST  addressdetails %addressdetails.attributes;>
@@ -283,10 +274,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  locality %locality.content;>
 <!ATTLIST  locality %locality.attributes;>
@@ -300,10 +288,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  localityname %localityname.content;>
 <!ATTLIST  localityname %localityname.attributes;>
@@ -317,10 +302,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  administrativearea %administrativearea.content;>
 <!ATTLIST  administrativearea %administrativearea.attributes;>
@@ -334,10 +316,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  thoroughfare %thoroughfare.content;>
 <!ATTLIST  thoroughfare %thoroughfare.attributes;>
@@ -353,10 +332,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  postalcode %postalcode.content;>
 <!ATTLIST  postalcode %postalcode.attributes;>
@@ -372,10 +348,7 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               %univ-atts;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+               %univ-atts;"
 >
 <!ELEMENT  country %country.content;>
 <!ATTLIST  country %country.attributes;>

--- a/doctypes/rng/bookmap/rng/bookmap.rng
+++ b/doctypes/rng/bookmap/rng/bookmap.rng
@@ -88,7 +88,6 @@ ORIGINAL CREATION DATE:
                          (map ditavalref-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (map mapgroup-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
@@ -115,7 +114,6 @@ ORIGINAL CREATION DATE:
      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
       <include href="../../technicalContent/rng/markupDomain.rng" dita:since="1.3"/>
       <include href="../../technicalContent/rng/programmingDomain.rng"/>
       <include href="../../technicalContent/rng/releaseManagementDomain.rng" dita:since="1.3"/>

--- a/doctypes/rng/bookmap/rng/bookmap.rng
+++ b/doctypes/rng/bookmap/rng/bookmap.rng
@@ -97,7 +97,11 @@ ORIGINAL CREATION DATE:
                          (topic ui-d)
                          (topic ut-d)
                          (topic xnal-d)
-                         a(props deliveryTarget)"/>
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"/>
          </optional>
       </define>
 
@@ -110,7 +114,11 @@ ORIGINAL CREATION DATE:
       <include href="bookmapMod.rng"/>
 
       <include href="../../technicalContent/rng/abbreviateDomain.rng"/>
-      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/bookmap/rng/bookmapMod.rng
+++ b/doctypes/rng/bookmap/rng/bookmapMod.rng
@@ -253,9 +253,6 @@ ORIGINAL CREATION DATE:
     <a:documentation>COMMON ATTRIBUTE SETS</a:documentation>
     <define name="chapter-atts">
       <optional>
-        <attribute name="navtitle"/>
-      </optional>
-      <optional>
         <attribute name="href"/>
       </optional>
       <optional>

--- a/doctypes/rng/bookmap/rng/bookmapMod.rng
+++ b/doctypes/rng/bookmap/rng/bookmapMod.rng
@@ -267,9 +267,6 @@ ORIGINAL CREATION DATE:
       <optional>
         <attribute name="copy-to"/>
       </optional>
-      <optional>
-        <attribute name="outputclass"/>
-      </optional>
       <ref name="topicref-atts"/>
       <ref name="univ-atts"/>
     </define>
@@ -457,9 +454,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="query"/>
         </optional>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <ref name="topicref-atts"/>
         <ref name="univ-atts"/>
       </define>
@@ -496,9 +490,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <optional>
           <attribute name="query"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
         <ref name="topicref-atts"/>
         <ref name="univ-atts"/>
@@ -704,9 +695,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="summary.element">
         <element name="summary" dita:longName="Summary">
@@ -823,9 +811,6 @@ ORIGINAL CREATION DATE:
             </choice>
           </attribute>
         </optional>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <attribute name="value"/>
       </define>
       <define name="publishtype.element">
@@ -856,9 +841,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="revisionid.element">
         <element name="revisionid" dita:longName="Revision ID">
@@ -917,9 +899,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="started.element">
         <element name="started" dita:longName="Start Date">
@@ -965,9 +944,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="completed.element">
         <element name="completed" dita:longName="Completion Date">
@@ -997,9 +973,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="year.element">
         <element name="year" dita:longName="Year">
@@ -1029,9 +1002,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="month.element">
         <element name="month" dita:longName="Month">
@@ -1061,9 +1031,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="day.element">
         <element name="day" dita:longName="Day">
@@ -1319,9 +1286,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="bookeventtype.element">
         <element name="bookeventtype" dita:longName="Book Event Type">
@@ -1621,9 +1585,6 @@ ORIGINAL CREATION DATE:
             </choice>
           </attribute>
         </optional>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <attribute name="value"/>
       </define>
       <define name="bookrestriction.element">
@@ -1690,9 +1651,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="booklibrary.element">
         <element name="booklibrary" dita:longName="Library Title">
@@ -1723,9 +1681,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="mainbooktitle.element">
         <element name="mainbooktitle" dita:longName="Main Book Title">
@@ -1755,9 +1710,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="booktitlealt.element">
         <element name="booktitlealt" dita:longName="Alternate Book Title">

--- a/doctypes/rng/bookmap/rng/bookmapMod.rng
+++ b/doctypes/rng/bookmap/rng/bookmapMod.rng
@@ -2227,367 +2227,306 @@ ORIGINAL CREATION DATE:
     <a:documentation>SPECIALIZATION ATTRIBUTES</a:documentation>
 
     <define name="bookmap.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/map bookmap/bookmap "/>
       </optional>
     </define>
     <define name="abbrevlist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/abbrevlist "/>
       </optional>
     </define>
     <define name="amendments.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/amendments "/>
       </optional>
     </define>
     <define name="appendices.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/appendices "/>
       </optional>
     </define>
     <define name="appendix.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/appendix "/>
       </optional>
     </define>
     <define name="approved.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/approved "/>
       </optional>
     </define>
     <define name="backmatter.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/backmatter "/>
       </optional>
     </define>
     <define name="bibliolist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/bibliolist "/>
       </optional>
     </define>
     <define name="bookabstract.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/bookabstract "/>
       </optional>
     </define>
     <define name="bookchangehistory.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookchangehistory "/>
       </optional>
     </define>
     <define name="bookevent.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookevent "/>
       </optional>
     </define>
     <define name="bookeventtype.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookeventtype "/>
       </optional>
     </define>
     <define name="bookid.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookid "/>
       </optional>
     </define>
     <define name="booklibrary.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/booklibrary "/>
       </optional>
     </define>
     <define name="booklist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/booklist "/>
       </optional>
     </define>
     <define name="booklists.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/booklists "/>
       </optional>
     </define>
     <define name="bookmeta.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicmeta bookmap/bookmeta "/>
       </optional>
     </define>
     <define name="booknumber.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/booknumber "/>
       </optional>
     </define>
     <define name="bookowner.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookowner "/>
       </optional>
     </define>
     <define name="bookpartno.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookpartno "/>
       </optional>
     </define>
     <define name="bookrestriction.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookrestriction "/>
       </optional>
     </define>
     <define name="bookrights.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/bookrights "/>
       </optional>
     </define>
     <define name="booktitle.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/title bookmap/booktitle "/>
       </optional>
     </define>
     <define name="booktitlealt.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/booktitlealt "/>
       </optional>
     </define>
     <define name="chapter.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/chapter "/>
       </optional>
     </define>
     <define name="colophon.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/colophon "/>
       </optional>
     </define>
     <define name="completed.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/completed "/>
       </optional>
     </define>
     <define name="copyrfirst.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/copyrfirst "/>
       </optional>
     </define>
     <define name="copyrlast.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/copyrlast "/>
       </optional>
     </define>
     <define name="day.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/day "/>
       </optional>
     </define>
     <define name="dedication.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/dedication "/>
       </optional>
     </define>
     <define name="draftintro.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/draftintro "/>
       </optional>
     </define>
     <define name="edited.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/edited "/>
       </optional>
     </define>
     <define name="edition.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/edition "/>
       </optional>
     </define>
     <define name="figurelist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/figurelist "/>
       </optional>
     </define>
     <define name="frontmatter.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/frontmatter "/>
       </optional>
     </define>
     <define name="glossarylist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/glossarylist "/>
       </optional>
     </define>
     <define name="indexlist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/indexlist "/>
       </optional>
     </define>
     <define name="isbn.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/isbn "/>
       </optional>
     </define>
     <define name="mainbooktitle.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/mainbooktitle "/>
       </optional>
     </define>
     <define name="maintainer.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/maintainer "/>
       </optional>
     </define>
     <define name="month.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/month "/>
       </optional>
     </define>
     <define name="notices.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/notices "/>
       </optional>
     </define>
     <define name="organization.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/organization "/>
       </optional>
     </define>
     <define name="part.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/part "/>
       </optional>
     </define>
     <define name="person.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/person "/>
       </optional>
     </define>
     <define name="preface.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/preface "/>
       </optional>
     </define>
     <define name="printlocation.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/printlocation "/>
       </optional>
     </define>
     <define name="published.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/published "/>
       </optional>
     </define>
     <define name="publisherinformation.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/publisher bookmap/publisherinformation "/>
       </optional>
     </define>
     <define name="publishtype.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/publishtype "/>
       </optional>
     </define>
     <define name="reviewed.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/reviewed "/>
       </optional>
     </define>
     <define name="revisionid.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/revisionid "/>
       </optional>
     </define>
     <define name="started.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/started "/>
       </optional>
     </define>
     <define name="summary.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/summary "/>
       </optional>
     </define>
     <define name="tablelist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/tablelist "/>
       </optional>
     </define>
     <define name="tested.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/tested "/>
       </optional>
     </define>
     <define name="toc.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/toc "/>
       </optional>
     </define>
     <define name="trademarklist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- map/topicref bookmap/trademarklist "/>
       </optional>
     </define>
     <define name="volume.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data bookmap/volume "/>
       </optional>
     </define>
     <define name="year.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph bookmap/year "/>
       </optional>

--- a/doctypes/rng/catalog.xml
+++ b/doctypes/rng/catalog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
    <nextCatalog catalog="bookmap/catalog.xml"/>
+   <nextCatalog catalog="classificationMap/catalog.xml"/>
    <nextCatalog catalog="machineryIndustry/catalog.xml"/>
    <nextCatalog catalog="technicalContent/catalog.xml"/>
    <nextCatalog catalog="xnal/catalog.xml"/>

--- a/doctypes/rng/classificationMap/catalog.xml
+++ b/doctypes/rng/classificationMap/catalog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+<!--DITA Classification map (tech comm map with classification domain) -->
+
+   <group><!-- System ID (URL) catalog entries -->
+      <system systemId="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:2.0"
+              uri="classifyMap.rng"/>
+      <!--<system systemId="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:1.x"
+              uri="rng/classifyMap.rng"/>
+      <system systemId="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng"
+              uri="rng/classifyMap.rng"/>-->
+   </group>
+   <group><!-- Public ID (URN) catalog entries -->
+      <uri name="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:2.0"
+           uri="classifyMap.rng"/>
+      <!--<uri name="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:1.x"
+           uri="rng/classifyMap.rng"/>
+      <uri name="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng"
+           uri="rng/classifyMap.rng"/>-->
+   </group>
+</catalog>

--- a/doctypes/rng/classificationMap/classifyMap.rng
+++ b/doctypes/rng/classificationMap/classifyMap.rng
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="urn:oasis:names:tc:dita:rng:checkShell.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="urn:oasis:names:tc:dita:rng:vocabularyModuleDesc.rng"
+                         schematypens="http://relaxng.org/ns/structure/1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:dita="http://dita.oasis-open.org/architecture/2005/"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+  <moduleDesc xmlns="http://dita.oasis-open.org/architecture/2005/">
+      <moduleTitle>DITA Classification Map Shell</moduleTitle>
+      <headerComment xml:space="preserve">
+=============================================================
+                   HEADER                                    
+=============================================================
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
+OASIS Standard
+16 January 2018 
+Copyright (c) OASIS Open 2018. All rights reserved. 
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+
+============================================================
+ MODULE:    DITA Classification Map
+ VERSION:   1.3
+ DATE:      November 2014
+                                                             
+=============================================================
+
+=============================================================
+                   PUBLIC DOCUMENT TYPE DEFINITION           
+                       TYPICAL INVOCATION                    
+                                                             
+Refer to this file by the following public identifier or an
+     appropriate system identifier:
+PUBLIC "-//OASIS//DTD DITA Classification Map//EN"
+     Delivered as file "classifyMap.dtd"                          
+
+=============================================================
+SYSTEM:     Darwin Information Typing Architecture (DITA)    
+                                                             
+PURPOSE:    DTD to describe DITA Classification maps         
+                                                             
+ORIGINAL CREATION DATE:                                      
+            March 2001                                       
+                                                             
+            (C) Copyright OASIS Open 2005, 2014.             
+            (C) Copyright IBM Corporation 2001, 2004.        
+            All Rights Reserved.                             
+                                                             
+ UPDATES:                                                    
+   2010.09.21 RDA: Added base topic domains                  
+   2014.03.13 WEK: Updated for DITA 1.3, reimplemented as RNG
+=============================================================
+    
+  </headerComment>
+      <moduleMetadata>
+         <moduleType>mapshell</moduleType>
+         <moduleShortName>classifyMap</moduleShortName>
+         <shellPublicIds>
+            <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Classification Map//EN</dtdShell>
+            <rncShell>urn:oasis:tc:tc:dita:spec:classification:rnc:classifyMap.rnc<var presep=":" name="ditaver"/>
+            </rncShell>
+            <rngShell>urn:oasis:tc:tc:dita:spec:classification:rng:classifyMap.rng<var presep=":" name="ditaver"/>
+            </rngShell>
+            <xsdShell>urn:oasis:tc:tc:dita:spec:classification:xsd:classifyMap.xsd<var presep=":" name="ditaver"/>
+            </xsdShell>
+         </shellPublicIds>
+      </moduleMetadata>
+  </moduleDesc>
+  <div>
+      <a:documentation>ROOT ELEMENT DECLARATION</a:documentation>
+      <start>
+         <ref name="map.element"/>
+      </start>
+
+  </div>
+  <div>
+      <a:documentation>DOMAINS ATTRIBUTE</a:documentation>
+      <define name="domains-att" combine="interleave">
+         <optional>
+            <attribute name="domains"
+                       a:defaultValue="(map classify-d)
+                         (topic abbrev-d)
+                         (map ditavalref-d)
+                         (map glossref-d)
+                         (topic hazard-d)
+                         (topic hi-d)
+                         (map mapgroup-d)
+                         (topic markup-d xml-d)
+                         (topic markup-d)
+                         (topic pr-d)
+                         (topic relmgmt-d)
+                         (topic sw-d)
+                         (topic ui-d)
+                         (topic ut-d)
+                         a(props deliveryTarget)"/>
+         </optional>
+      </define>
+
+  </div>
+  <div>
+      <a:documentation>MODULE INCLUSIONS</a:documentation>
+     <include href="urn:oasis:names:tc:dita:rng:mapMod.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
+  
+     <include href="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"/>
+      <include href="../technicalContent/rng/abbreviateDomain.rng"/>
+     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
+      <include href="../technicalContent/rng/glossrefDomain.rng"/>
+     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
+      <include href="../technicalContent/rng/markupDomain.rng" dita:since="1.3"/>
+      <include href="../technicalContent/rng/programmingDomain.rng"/>
+      <include href="../technicalContent/rng/releaseManagementDomain.rng"
+               dita:since="1.3"/>
+      <include href="../technicalContent/rng/softwareDomain.rng"/>
+      <include href="../technicalContent/rng/uiDomain.rng"/>
+     <include href="urn:oasis:names:tc:dita:rng:utilitiesDomain.rng:2.0"/>
+      <include href="../technicalContent/rng/xmlDomain.rng" dita:since="1.3"/>    </div>
+  <div>
+      <a:documentation>ID-DEFINING-ELEMENT OVERRIDES</a:documentation>
+      <define name="any">
+         <zeroOrMore>
+            <choice>
+               <ref name="idElements"/>
+               <element>
+                  <anyName>
+                     <except>
+                        <name>map</name>
+                        <name>anchor</name>
+                     </except>
+                  </anyName>
+                  <zeroOrMore>
+                     <attribute>
+                        <anyName/>
+                     </attribute>
+                  </zeroOrMore>
+                  <ref name="any"/>
+               </element>
+               <text/>
+            </choice>
+         </zeroOrMore>
+      </define>
+  </div>
+</grammar>

--- a/doctypes/rng/machineryIndustry/rng/machineryTask.rng
+++ b/doctypes/rng/machineryIndustry/rng/machineryTask.rng
@@ -112,7 +112,6 @@ ORIGINAL CREATION DATE:
       <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
       <include href="../../technicalContent/rng/svgDomain.rng" dita:since="1.3"/>

--- a/doctypes/rng/machineryIndustry/rng/machineryTask.rng
+++ b/doctypes/rng/machineryIndustry/rng/machineryTask.rng
@@ -83,7 +83,11 @@ ORIGINAL CREATION DATE:
                          (topic task+taskreq-d machineryTaskbody-c)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"/>
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"/>
          </optional>
       </define>
 
@@ -103,7 +107,12 @@ ORIGINAL CREATION DATE:
 
       <include href="urn:oasis:names:tc:dita:rng:topicMod.rng:2.0"/>
     
+      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
       <include href="../../technicalContent/rng/svgDomain.rng" dita:since="1.3"/>

--- a/doctypes/rng/machineryIndustry/rng/machineryTask.rng
+++ b/doctypes/rng/machineryIndustry/rng/machineryTask.rng
@@ -77,7 +77,6 @@ ORIGINAL CREATION DATE:
             <attribute name="domains"
                        a:defaultValue="(topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic svg-d)
                          (topic task taskreq-d)
                          (topic task)
@@ -107,7 +106,6 @@ ORIGINAL CREATION DATE:
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
       <include href="../../technicalContent/rng/svgDomain.rng" dita:since="1.3"/>
       <include href="../../technicalContent/rng/taskreqDomain.rng"/>
       <include href="../../technicalContent/rng/uiDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/abbreviateDomain.rng
+++ b/doctypes/rng/technicalContent/rng/abbreviateDomain.rng
@@ -98,7 +98,6 @@ ORIGINAL CREATION DATE:
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="abbreviated-form.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/term abbrev-d/abbreviated-form "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/abbreviateDomain.rng
+++ b/doctypes/rng/technicalContent/rng/abbreviateDomain.rng
@@ -81,9 +81,6 @@ ORIGINAL CREATION DATE:
       <define name="abbreviated-form.attributes">
         <attribute name="keyref"/>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="abbreviated-form.element">
         <element name="abbreviated-form" dita:longName="Abbreviated Form">

--- a/doctypes/rng/technicalContent/rng/concept.rng
+++ b/doctypes/rng/technicalContent/rng/concept.rng
@@ -113,7 +113,12 @@ ORIGINAL CREATION DATE:
       </define>
     </include>
     <include href="abbreviateDomain.rng"/>
+    <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+    <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/concept.rng
+++ b/doctypes/rng/technicalContent/rng/concept.rng
@@ -85,7 +85,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -114,7 +113,6 @@ ORIGINAL CREATION DATE:
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
     <include href="markupDomain.rng" dita:since="1.3"/>
     <include href="mathmlDomain.rng" dita:since="1.3"/>
     <include href="programmingDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/concept.rng
+++ b/doctypes/rng/technicalContent/rng/concept.rng
@@ -94,7 +94,11 @@ ORIGINAL CREATION DATE:
                          (topic sw-d)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"
         />
       </optional>
     </define>

--- a/doctypes/rng/technicalContent/rng/concept.rng
+++ b/doctypes/rng/technicalContent/rng/concept.rng
@@ -118,7 +118,6 @@ ORIGINAL CREATION DATE:
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/conceptMod.rng
+++ b/doctypes/rng/technicalContent/rng/conceptMod.rng
@@ -212,19 +212,16 @@ ORIGINAL CREATION DATE:
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
 
     <define name="concept.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/topic concept/concept "/>
       </optional>
     </define>
     <define name="conbody.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/body  concept/conbody "/>
       </optional>
     </define>
     <define name="conbodydiv.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/bodydiv concept/conbodydiv "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/conceptMod.rng
+++ b/doctypes/rng/technicalContent/rng/conceptMod.rng
@@ -193,9 +193,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="conbodydiv.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="conbodydiv.element">
         <element name="conbodydiv" dita:longName="Concept Body division">

--- a/doctypes/rng/technicalContent/rng/ditabase.rng
+++ b/doctypes/rng/technicalContent/rng/ditabase.rng
@@ -107,7 +107,11 @@ ORIGINAL CREATION DATE:
                          (topic troubleshooting++task)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"/>
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"/>
          </optional>
       </define>
   </div>
@@ -136,7 +140,12 @@ ORIGINAL CREATION DATE:
       <include href="troubleshootingMod.rng"/>
     
       <include href="abbreviateDomain.rng"/>
+     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/ditabase.rng
+++ b/doctypes/rng/technicalContent/rng/ditabase.rng
@@ -167,7 +167,6 @@ ORIGINAL CREATION DATE:
       <define name="dita.attlist" combine="interleave">
         <ref name="arch-atts"/>
         <ref name="localization-atts" dita:since="DITA 1.3"/>
-        <ref name="global-atts"/>
       </define>
 
   </div>

--- a/doctypes/rng/technicalContent/rng/ditabase.rng
+++ b/doctypes/rng/technicalContent/rng/ditabase.rng
@@ -145,7 +145,6 @@ ORIGINAL CREATION DATE:
      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/ditabase.rng
+++ b/doctypes/rng/technicalContent/rng/ditabase.rng
@@ -94,7 +94,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -141,7 +140,6 @@ ORIGINAL CREATION DATE:
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
       <include href="markupDomain.rng" dita:since="1.3"/>
       <include href="mathmlDomain.rng" dita:since="1.3"/>
       <include href="programmingDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/equationDomain.rng
+++ b/doctypes/rng/technicalContent/rng/equationDomain.rng
@@ -94,9 +94,6 @@ Copyright (c) OASIS Open 2014
       </define>
       <define name="equation-inline.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="equation-inline.element">
         <element name="equation-inline" dita:longName="Inline equation" dita:since="1.3">
@@ -125,9 +122,6 @@ Copyright (c) OASIS Open 2014
       </define>
       <define name="equation-block.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="equation-block.element">
         <element name="equation-block" dita:longName="Block equation" dita:since="1.3">
@@ -158,9 +152,6 @@ Copyright (c) OASIS Open 2014
       </define>
       <define name="equation-number.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="equation-number.element">
         <element name="equation-number" dita:longName="Equation number" dita:since="1.3">
@@ -198,9 +189,6 @@ Copyright (c) OASIS Open 2014
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="equation-figure.element">
         <element name="equation-figure" dita:longName="Equation figure" dita:since="1.3">

--- a/doctypes/rng/technicalContent/rng/equationDomain.rng
+++ b/doctypes/rng/technicalContent/rng/equationDomain.rng
@@ -219,25 +219,21 @@ Copyright (c) OASIS Open 2014
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="equation-inline.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph equation-d/equation-inline "/>
       </optional>
     </define>
     <define name="equation-block.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/div equation-d/equation-block "/>
       </optional>
     </define>
     <define name="equation-number.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph equation-d/equation-number "/>
       </optional>
     </define>
     <define name="equation-figure.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/fig equation-d/equation-figure "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/generalTask.rng
+++ b/doctypes/rng/technicalContent/rng/generalTask.rng
@@ -79,7 +79,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -109,7 +108,6 @@ ORIGINAL CREATION DATE:
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
     <include href="markupDomain.rng" dita:since="1.3"/>
     <include href="mathmlDomain.rng" dita:since="1.3"/>
     <include href="programmingDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/generalTask.rng
+++ b/doctypes/rng/technicalContent/rng/generalTask.rng
@@ -89,7 +89,11 @@ ORIGINAL CREATION DATE:
                          (topic task)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"
         />
       </optional>
     </define>
@@ -104,7 +108,12 @@ ORIGINAL CREATION DATE:
       </define>
     </include>
     <include href="abbreviateDomain.rng"/>
+    <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+    <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/generalTask.rng
+++ b/doctypes/rng/technicalContent/rng/generalTask.rng
@@ -113,7 +113,6 @@ ORIGINAL CREATION DATE:
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/glossentry.rng
+++ b/doctypes/rng/technicalContent/rng/glossentry.rng
@@ -91,7 +91,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -118,7 +117,6 @@ ORIGINAL CREATION DATE:
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
       <include href="abbreviateDomain.rng"/>
       <include href="markupDomain.rng" dita:since="1.3"/>
       <include href="mathmlDomain.rng" dita:since="1.3"/>

--- a/doctypes/rng/technicalContent/rng/glossentry.rng
+++ b/doctypes/rng/technicalContent/rng/glossentry.rng
@@ -100,7 +100,11 @@ ORIGINAL CREATION DATE:
                          (topic sw-d)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"/>
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"/>
          </optional>
       </define>
   </div>
@@ -113,7 +117,12 @@ ORIGINAL CREATION DATE:
           <empty/>
         </define>
       </include>
+     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/glossentry.rng
+++ b/doctypes/rng/technicalContent/rng/glossentry.rng
@@ -122,7 +122,6 @@ ORIGINAL CREATION DATE:
      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/glossentryMod.rng
+++ b/doctypes/rng/technicalContent/rng/glossentryMod.rng
@@ -771,103 +771,86 @@ ORIGINAL CREATION DATE:
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
 
     <define name="glossentry.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/topic concept/concept glossentry/glossentry "/>
       </optional>
     </define>
     <define name="glossterm.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/title concept/title glossentry/glossterm "/>
       </optional>
     </define>
     <define name="glossdef.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/abstract concept/abstract glossentry/glossdef "/>
       </optional>
     </define>
     <define name="glossBody.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/body concept/conbody glossentry/glossBody "/>
       </optional>
     </define>
     <define name="glossAbbreviation.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/title concept/title glossentry/glossAbbreviation "/>
       </optional>
     </define>
     <define name="glossAcronym.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/title concept/title glossentry/glossAcronym "/>
       </optional>
     </define>
     <define name="glossShortForm.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/title concept/title glossentry/glossShortForm "/>
       </optional>
     </define>
     <define name="glossSynonym.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/title concept/title glossentry/glossSynonym "/>
       </optional>
     </define>
     <define name="glossPartOfSpeech.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data concept/data glossentry/glossPartOfSpeech "/>
       </optional>
     </define>
     <define name="glossProperty.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data concept/data glossentry/glossProperty "/>
       </optional>
     </define>
     <define name="glossStatus.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/data concept/data glossentry/glossStatus "/>
       </optional>
     </define>
     <define name="glossAlt.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section concept/section glossentry/glossAlt "/>
       </optional>
     </define>
     <define name="glossAlternateFor.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/xref concept/xref glossentry/glossAlternateFor "/>
       </optional>
     </define>
     <define name="glossScopeNote.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/note concept/note glossentry/glossScopeNote "/>
       </optional>
     </define>
     <define name="glossSurfaceForm.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/p concept/p glossentry/glossSurfaceForm "/>
       </optional>
     </define>
     <define name="glossSymbol.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/image concept/image glossentry/glossSymbol "/>
       </optional>
     </define>
     <define name="glossUsage.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/note concept/note glossentry/glossUsage "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/glossentryMod.rng
+++ b/doctypes/rng/technicalContent/rng/glossentryMod.rng
@@ -206,9 +206,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="glossdef.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="glossdef.element">
         <element name="glossdef" dita:longName="Glossary Definition">
@@ -500,9 +497,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="glossSurfaceForm.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="glossSurfaceForm.element">
         <element name="glossSurfaceForm" dita:longName="Glossary Surface Form">
@@ -548,9 +542,6 @@ ORIGINAL CREATION DATE:
           <attribute name="othertype"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="glossUsage.element">
         <element name="glossUsage" dita:longName="Glossary Usage">
@@ -595,9 +586,6 @@ ORIGINAL CREATION DATE:
           <attribute name="othertype"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="glossScopeNote.element">
         <element name="glossScopeNote" dita:longName="Glossary Scope Note">
@@ -680,9 +668,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="glossSymbol.element">
         <element name="glossSymbol" dita:longName="Glossary Symbol">
@@ -725,9 +710,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="glossAlt.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="glossAlt.element">
         <element name="glossAlt" dita:longName="Glossary Alternate Form">
@@ -771,9 +753,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="glossAlternateFor.element">
         <element name="glossAlternateFor" dita:longName="Glossary - Alternate For">

--- a/doctypes/rng/technicalContent/rng/glossgroup.rng
+++ b/doctypes/rng/technicalContent/rng/glossgroup.rng
@@ -76,7 +76,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -102,7 +101,6 @@ ORIGINAL CREATION DATE:
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
     <include href="abbreviateDomain.rng"/>
     <include href="markupDomain.rng" dita:since="1.3"/>
     <include href="mathmlDomain.rng" dita:since="1.3"/>

--- a/doctypes/rng/technicalContent/rng/glossgroup.rng
+++ b/doctypes/rng/technicalContent/rng/glossgroup.rng
@@ -106,7 +106,6 @@ ORIGINAL CREATION DATE:
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/glossgroup.rng
+++ b/doctypes/rng/technicalContent/rng/glossgroup.rng
@@ -85,7 +85,11 @@ ORIGINAL CREATION DATE:
                          (topic sw-d)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"
         />
       </optional>
     </define>
@@ -97,7 +101,12 @@ ORIGINAL CREATION DATE:
     <include href="conceptMod.rng"/>
     <include href="glossentryMod.rng"/>
     <include href="glossgroupMod.rng"/>
+    <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+    <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/glossgroupMod.rng
+++ b/doctypes/rng/technicalContent/rng/glossgroupMod.rng
@@ -112,7 +112,6 @@ ORIGINAL CREATION DATE:
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
 
     <define name="glossgroup.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/topic concept/concept glossgroup/glossgroup "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/glossrefDomain.rng
+++ b/doctypes/rng/technicalContent/rng/glossrefDomain.rng
@@ -199,7 +199,6 @@ ORIGINAL CREATION DATE:
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="glossref.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ map/topicref glossref-d/glossref "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/glossrefDomain.rng
+++ b/doctypes/rng/technicalContent/rng/glossrefDomain.rng
@@ -77,9 +77,6 @@ ORIGINAL CREATION DATE:
         </optional>
       </define>
       <define name="glossref.attributes">
-        <optional>
-          <attribute name="navtitle"/>
-        </optional>
         <optional dita:since="DITA 1.3">
           <attribute name="href"/>
         </optional>

--- a/doctypes/rng/technicalContent/rng/glossrefDomain.rng
+++ b/doctypes/rng/technicalContent/rng/glossrefDomain.rng
@@ -94,9 +94,6 @@ ORIGINAL CREATION DATE:
           <attribute name="copy-to"/>
         </optional>
         <optional>
-          <attribute name="outputclass"/>
-        </optional>
-        <optional>
           <attribute name="collection-type">
             <choice>
               <value>choice</value>

--- a/doctypes/rng/technicalContent/rng/map.rng
+++ b/doctypes/rng/technicalContent/rng/map.rng
@@ -95,7 +95,6 @@ ORIGINAL CREATION DATE:
                          (map glossref-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (map mapgroup-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
@@ -119,7 +118,6 @@ ORIGINAL CREATION DATE:
       <include href="glossrefDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
       <include href="markupDomain.rng" dita:since="1.3"/>
       <include href="programmingDomain.rng"/>
       <include href="releaseManagementDomain.rng" dita:since="1.3"/>

--- a/doctypes/rng/technicalContent/rng/map.rng
+++ b/doctypes/rng/technicalContent/rng/map.rng
@@ -103,7 +103,11 @@ ORIGINAL CREATION DATE:
                          (topic sw-d)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"/>
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"/>
          </optional>
       </define>
   </div>
@@ -113,7 +117,12 @@ ORIGINAL CREATION DATE:
      <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
 
       <include href="abbreviateDomain.rng"/>
-      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="glossrefDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/map.rng
+++ b/doctypes/rng/technicalContent/rng/map.rng
@@ -123,7 +123,6 @@ ORIGINAL CREATION DATE:
      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
-     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="glossrefDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/markupDomain.rng
+++ b/doctypes/rng/technicalContent/rng/markupDomain.rng
@@ -66,9 +66,6 @@
       </define>
       <define name="markupname.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="markupname.element">
         <element name="markupname" dita:longName="Markup name" dita:since="1.3">

--- a/doctypes/rng/technicalContent/rng/markupDomain.rng
+++ b/doctypes/rng/technicalContent/rng/markupDomain.rng
@@ -81,7 +81,6 @@
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="markupname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute a:defaultValue="+ topic/keyword markup-d/markupname " name="class"/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/mathmlDomain.rng
+++ b/doctypes/rng/technicalContent/rng/mathmlDomain.rng
@@ -106,9 +106,6 @@ All Rights Reserved.
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
 
       <define name="mathmlref.element">
@@ -181,9 +178,6 @@ elements
 
       <define name="mathml.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
 
       <define name="mathml.element">

--- a/doctypes/rng/technicalContent/rng/mathmlDomain.rng
+++ b/doctypes/rng/technicalContent/rng/mathmlDomain.rng
@@ -214,14 +214,12 @@ elements
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
 
     <define name="mathml.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/foreign mathml-d/mathml "/>
       </optional>
     </define>
 
     <define name="mathmlref.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/xref mathml-d/mathmlref "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/programmingDomain.rng
+++ b/doctypes/rng/technicalContent/rng/programmingDomain.rng
@@ -1137,157 +1137,131 @@ ORIGINAL CREATION DATE:
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
 
     <define name="apiname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword pr-d/apiname "/>
       </optional>
     </define>
     <define name="codeblock.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/pre pr-d/codeblock "/>
       </optional>
     </define>
     <define name="codeph.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph pr-d/codeph "/>
       </optional>
     </define>
     <define name="coderef.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/xref pr-d/coderef "/>
       </optional>
     </define>
     <define name="delim.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph pr-d/delim "/>
       </optional>
     </define>
     <define name="fragment.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/figgroup pr-d/fragment "/>
       </optional>
     </define>
     <define name="fragref.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/xref pr-d/fragref "/>
       </optional>
     </define>
     <define name="groupchoice.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/figgroup pr-d/groupchoice "/>
       </optional>
     </define>
     <define name="groupcomp.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/figgroup pr-d/groupcomp "/>
       </optional>
     </define>
     <define name="groupseq.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/figgroup pr-d/groupseq "/>
       </optional>
     </define>
     <define name="kwd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword pr-d/kwd "/>
       </optional>
     </define>
     <define name="oper.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph pr-d/oper "/>
       </optional>
     </define>
     <define name="option.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword pr-d/option "/>
       </optional>
     </define>
     <define name="parml.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/dl pr-d/parml "/>
       </optional>
     </define>
     <define name="parmname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword pr-d/parmname "/>
       </optional>
     </define>
     <define name="pd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/dd pr-d/pd "/>
       </optional>
     </define>
     <define name="plentry.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/dlentry pr-d/plentry "/>
       </optional>
     </define>
     <define name="pt.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/dt pr-d/pt "/>
       </optional>
     </define>
     <define name="repsep.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph pr-d/repsep "/>
       </optional>
     </define>
     <define name="sep.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph pr-d/sep "/>
       </optional>
     </define>
     <define name="synblk.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/figgroup pr-d/synblk "/>
       </optional>
     </define>
     <define name="synnote.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/fn pr-d/synnote "/>
       </optional>
     </define>
     <define name="synnoteref.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/xref pr-d/synnoteref "/>
       </optional>
     </define>
     <define name="synph.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph pr-d/synph "/>
       </optional>
     </define>
     <define name="syntaxdiagram.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/fig pr-d/syntaxdiagram "/>
       </optional>
     </define>
     <define name="var.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph pr-d/var "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/programmingDomain.rng
+++ b/doctypes/rng/technicalContent/rng/programmingDomain.rng
@@ -190,6 +190,9 @@ ORIGINAL CREATION DATE:
         <ref name="filter-atts"/>
         <ref name="localization-atts"/>
         <optional>
+          <attribute name="outputclass"/>
+        </optional>
+        <optional>
           <attribute name="rev"/>
         </optional>
         <optional>
@@ -224,9 +227,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="codeph.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="codeph.element">
         <element name="codeph" dita:longName="Code Phrase">
@@ -267,9 +267,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="codeblock.element">
         <element name="codeblock" dita:longName="Code Block">
@@ -314,9 +311,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="coderef.element">
         <element name="coderef" dita:longName="Literal code reference">
@@ -346,9 +340,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="option.element">
         <element name="option" dita:longName="Option">
@@ -383,9 +374,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="var.element">
         <element name="var" dita:longName="Variable">
@@ -416,9 +404,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="parmname.element">
         <element name="parmname" dita:longName="Parameter Name">
@@ -455,9 +440,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="synph.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="synph.element">
         <element name="synph" dita:longName="Syntax Phrase">
@@ -492,9 +474,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="oper.element">
         <element name="oper" dita:longName="Operator">
@@ -528,9 +507,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="delim.element">
         <element name="delim" dita:longName="Delimiter">
@@ -564,9 +540,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="sep.element">
         <element name="sep" dita:longName="Separator">
@@ -597,9 +570,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="apiname.element">
         <element name="apiname" dita:longName="API Name">
@@ -642,9 +612,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="parml.element">
         <element name="parml" dita:longName="Parameter List">
@@ -672,9 +639,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="plentry.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="plentry.element">
         <element name="plentry" dita:longName="Parameter List Entry">
@@ -702,9 +666,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="pt.element">
         <element name="pt" dita:longName="Parameter Term">
@@ -729,9 +690,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="pd.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="pd.element">
         <element name="pd" dita:longName="Parameter Description">
@@ -769,9 +727,6 @@ ORIGINAL CREATION DATE:
       <define name="syntaxdiagram.attributes">
         <ref name="display-atts"/>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="syntaxdiagram.element">
         <element name="syntaxdiagram" dita:longName="Syntax Diagram">
@@ -807,9 +762,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="synblk.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="synblk.element">
         <element name="synblk" dita:longName="Syntax Block">
@@ -862,9 +814,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="groupseq.element">
         <element name="groupseq" dita:longName="Sequence Group">
@@ -917,9 +866,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="groupchoice.element">
         <element name="groupchoice" dita:longName="Choice Group">
@@ -972,9 +918,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="groupcomp.element">
         <element name="groupcomp" dita:longName="Composite group">
@@ -1009,9 +952,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="fragment.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="fragment.element">
         <element name="fragment" dita:longName="Fragment">
@@ -1048,9 +988,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="fragref.element">
         <element name="fragref" dita:longName="Fragment Reference">
@@ -1081,9 +1018,6 @@ ORIGINAL CREATION DATE:
           <attribute name="callout"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="synnote.element">
         <element name="synnote" dita:longName="Syntax Diagram Note">
@@ -1109,9 +1043,6 @@ ORIGINAL CREATION DATE:
           <attribute name="href"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="synnoteref.element">
         <element name="synnoteref" dita:longName="Syntax Note Reference">
@@ -1145,9 +1076,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="repsep.element" >
         <element name="repsep" dita:longName="Repeat Separator">
@@ -1188,9 +1116,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="kwd.element">
         <element name="kwd" dita:longName="Syntax Keyword">

--- a/doctypes/rng/technicalContent/rng/reference.rng
+++ b/doctypes/rng/technicalContent/rng/reference.rng
@@ -84,7 +84,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -114,7 +113,6 @@ ORIGINAL CREATION DATE:
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
     <include href="markupDomain.rng" dita:since="1.3"/>
     <include href="mathmlDomain.rng" dita:since="1.3"/>
     <include href="programmingDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/reference.rng
+++ b/doctypes/rng/technicalContent/rng/reference.rng
@@ -118,7 +118,6 @@ ORIGINAL CREATION DATE:
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/reference.rng
+++ b/doctypes/rng/technicalContent/rng/reference.rng
@@ -94,7 +94,11 @@ ORIGINAL CREATION DATE:
                          (topic sw-d)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"
         />
       </optional>
     </define>
@@ -109,7 +113,12 @@ ORIGINAL CREATION DATE:
       </define>
     </include>
     <include href="abbreviateDomain.rng"/>
+    <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+    <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/referenceMod.rng
+++ b/doctypes/rng/technicalContent/rng/referenceMod.rng
@@ -551,79 +551,66 @@ ORIGINAL CREATION DATE:
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
 
     <define name="reference.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/topic       reference/reference "/>
       </optional>
     </define>
     <define name="refbody.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/body        reference/refbody "/>
       </optional>
     </define>
     <define name="refbodydiv.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/bodydiv     reference/refbodydiv "/>
       </optional>
     </define>
     <define name="refsyn.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section     reference/refsyn "/>
       </optional>
     </define>
     <define name="properties.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/simpletable reference/properties "/>
       </optional>
     </define>
     <define name="property.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/strow       reference/property "/>
       </optional>
     </define>
     <define name="proptype.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry     reference/proptype "/>
       </optional>
     </define>
     <define name="propvalue.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry     reference/propvalue "/>
       </optional>
     </define>
     <define name="propdesc.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry     reference/propdesc "/>
       </optional>
     </define>
     <define name="prophead.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/sthead      reference/prophead "/>
       </optional>
     </define>
     <define name="proptypehd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry     reference/proptypehd "/>
       </optional>
     </define>
     <define name="propvaluehd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry     reference/propvaluehd "/>
       </optional>
     </define>
     <define name="propdeschd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry     reference/propdeschd "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/referenceMod.rng
+++ b/doctypes/rng/technicalContent/rng/referenceMod.rng
@@ -231,9 +231,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="refbodydiv.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="refbodydiv.element">
         <element name="refbodydiv" dita:longName="Reference Body division">
@@ -260,9 +257,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="refsyn.element">
         <element name="refsyn" dita:longName="Reference Syntax">
@@ -308,9 +302,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <ref name="display-atts"/>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="properties.element">
         <element name="properties" dita:longName="Properties">
@@ -342,9 +333,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="prophead.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="prophead.element">
         <element name="prophead" dita:longName="Property Head">
@@ -373,9 +361,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="proptypehd.element">
         <element name="proptypehd" dita:longName="Property Type Head">
@@ -403,9 +388,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="propvaluehd.element">
         <element name="propvaluehd" dita:longName="Property Value Head">
@@ -434,9 +416,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="propdeschd.element">
         <element name="propdeschd" dita:longName="Property Description Head">
@@ -467,9 +446,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="property.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="property.element">
         <element name="property" dita:longName="Property">
@@ -498,9 +474,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="proptype.element">
         <element name="proptype" dita:longName="Property Type">
@@ -529,9 +502,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="propvalue.element">
         <element name="propvalue" dita:longName="Property Value">
@@ -560,9 +530,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="propdesc.element">
         <element name="propdesc" dita:longName="Property Description">

--- a/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
+++ b/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
@@ -426,67 +426,56 @@ PUBLIC "-//OASIS//ENTITIES DITA Release Management Domain//EN"
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="change-historylist.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/metadata relmgmt-d/change-historylist "/>
       </optional>
     </define>
     <define name="change-item.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-item "/>
       </optional>
     </define>
     <define name="change-person.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-person "/>
       </optional>
     </define>
     <define name="change-organization.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-organization "/>
       </optional>
     </define>
     <define name="change-revisionid.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-revisionid "/>
       </optional>
     </define>
     <define name="change-request-reference.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-request-reference "/>
       </optional>
     </define>
     <define name="change-request-system.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-request-system "/>
       </optional>
     </define>
     <define name="change-request-id.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-request-id "/>
       </optional>
     </define>
     <define name="change-started.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-started "/>
       </optional>
     </define>
     <define name="change-completed.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-completed "/>
       </optional>
     </define>
     <define name="change-summary.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data relmgmt-d/change-summary "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
+++ b/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
@@ -94,9 +94,6 @@ PUBLIC "-//OASIS//ENTITIES DITA Release Management Domain//EN"
       <optional>
         <attribute name="datatype"/>
       </optional>
-      <optional>
-        <attribute name="outputclass"/>
-      </optional>
     </define>
   </div>
   <div>

--- a/doctypes/rng/technicalContent/rng/softwareDomain.rng
+++ b/doctypes/rng/technicalContent/rng/softwareDomain.rng
@@ -127,9 +127,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="msgph.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="msgph.element">
         <element name="msgph" dita:longName="Message Phrase">
@@ -162,9 +159,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
         <optional>
           <attribute name="xml:space" a:defaultValue="preserve">
             <value>preserve</value>
@@ -201,9 +195,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="msgnum.element">
         <element name="msgnum" dita:longName="Message Number">
@@ -235,9 +226,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="cmdname.element">
         <element name="cmdname" dita:longName="Command Name">
@@ -269,9 +257,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="varname.element">
         <element name="varname" dita:longName="Variable Name">
@@ -297,9 +282,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="filepath.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="filepath.element">
         <element name="filepath" dita:longName="File Path">
@@ -330,9 +312,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="userinput.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="userinput.element">
         <element name="userinput" dita:longName="User Input">
@@ -358,9 +337,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="systemoutput.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="systemoutput.element">
         <element name="systemoutput" dita:longName="System Output">

--- a/doctypes/rng/technicalContent/rng/softwareDomain.rng
+++ b/doctypes/rng/technicalContent/rng/softwareDomain.rng
@@ -357,49 +357,41 @@ ORIGINAL CREATION DATE:
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="cmdname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword sw-d/cmdname "/>
       </optional>
     </define>
     <define name="filepath.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph sw-d/filepath "/>
       </optional>
     </define>
     <define name="msgblock.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/pre sw-d/msgblock "/>
       </optional>
     </define>
     <define name="msgnum.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword sw-d/msgnum "/>
       </optional>
     </define>
     <define name="msgph.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph sw-d/msgph "/>
       </optional>
     </define>
     <define name="systemoutput.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph sw-d/systemoutput "/>
       </optional>
     </define>
     <define name="userinput.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph sw-d/userinput "/>
       </optional>
     </define>
     <define name="varname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword sw-d/varname "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/svgDomain.rng
+++ b/doctypes/rng/technicalContent/rng/svgDomain.rng
@@ -70,9 +70,6 @@ DITA SVG Domain
       </define>
       <define name="svg-container.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="svg-container.element">
         <element name="svg-container" ditaarch:longName="SVG container"
@@ -102,9 +99,6 @@ DITA SVG Domain
           <attribute name="format" a:defaultValue="svg"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="svgref.element">
         <element name="svgref" dita:longName="SVG element reference"

--- a/doctypes/rng/technicalContent/rng/svgDomain.rng
+++ b/doctypes/rng/technicalContent/rng/svgDomain.rng
@@ -116,13 +116,11 @@ DITA SVG Domain
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="svg-container.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/foreign svg-d/svg-container "/>
       </optional>
     </define>
     <define name="svgref.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/xref svg-d/svgref "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/task.rng
+++ b/doctypes/rng/technicalContent/rng/task.rng
@@ -125,7 +125,6 @@ ORIGINAL CREATION DATE:
      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/task.rng
+++ b/doctypes/rng/technicalContent/rng/task.rng
@@ -87,7 +87,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -121,7 +120,6 @@ ORIGINAL CREATION DATE:
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
       <include href="markupDomain.rng" dita:since="1.3"/>
       <include href="mathmlDomain.rng" dita:since="1.3"/>
       <include href="programmingDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/task.rng
+++ b/doctypes/rng/technicalContent/rng/task.rng
@@ -98,7 +98,11 @@ ORIGINAL CREATION DATE:
                          (topic task)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"/>
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"/>
          </optional>
       </define>
 
@@ -116,7 +120,12 @@ ORIGINAL CREATION DATE:
       <a:documentation> MODULE INCLUSIONS </a:documentation>
       <include href="urn:oasis:names:tc:dita:rng:topicMod.rng:2.0"/>
       <include href="abbreviateDomain.rng"/>
+     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/taskMod.rng
+++ b/doctypes/rng/technicalContent/rng/taskMod.rng
@@ -191,6 +191,9 @@ ORIGINAL CREATION DATE:
         </attribute>
       </optional>
       <ref name="localization-atts"/>
+      <optional>
+        <attribute name="outputclass"/>
+      </optional>
     </define>
 
   </div>
@@ -322,9 +325,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="prereq.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="prereq.element">
         <element name="prereq" dita:longName="Prerequisites">
@@ -350,9 +350,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="context.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="context.element">
         <element name="context" dita:longName="Context">
@@ -378,9 +375,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="steps-informal.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <a:documentation>
         <![CDATA[The <steps-informal> element allows authors to describe procedural task information that would not normally be described as steps. ]]></a:documentation>
@@ -415,9 +409,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="steps.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="steps.element">
         <element name="steps" dita:longName="Steps">
@@ -454,9 +445,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="steps-unordered.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="steps-unordered.element">
         <element name="steps-unordered" dita:longName="Unordered steps">
@@ -482,9 +470,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="stepsection.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <a:documentation>
         <![CDATA[The <stepsection> element provides expository text before a step element. Although the element is specialized from <li> and has the same content model as a list item, this is not considered a step, and rendering engines may choose to skip this element when numbering steps. ]]></a:documentation>
@@ -535,9 +520,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance-task"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="step.element">
         <element name="step" dita:longName="Step">
@@ -566,9 +548,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="cmd.element">
         <element name="cmd" dita:longName="Command">
@@ -594,9 +573,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="info.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="info.element">
         <element name="info" dita:longName="Information">
@@ -627,9 +603,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="substeps.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="substeps.element">
         <element name="substeps" dita:longName="Sub-steps">
@@ -676,9 +649,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts-no-importance-task"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="substep.element">
         <element name="substep" dita:longName="Sub-step">
@@ -704,9 +674,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="tutorialinfo.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="tutorialinfo.element">
         <element name="tutorialinfo" dita:longName="Tutorial Information">
@@ -732,9 +699,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="stepxmp.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="stepxmp.element">
         <element name="stepxmp" dita:longName="Step Example">
@@ -766,9 +730,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="choices.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="choices.element">
         <element name="choices" dita:longName="Choices">
@@ -794,9 +755,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="choice.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="choice.element">
         <element name="choice" dita:longName="Choice">
@@ -842,9 +800,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <ref name="display-atts"/>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="choicetable.element">
         <element name="choicetable" dita:longName="Choice Table">
@@ -869,9 +824,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="chhead.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="chhead.element">
         <element name="chhead" dita:longName="Choice Head">
@@ -900,9 +852,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="choptionhd.element">
         <element name="choptionhd" dita:longName="Choice Option Head">
@@ -931,9 +880,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="chdeschd.element">
         <element name="chdeschd" dita:longName="Choice Description Head">
@@ -958,9 +904,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="chrow.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="chrow.element">
         <element name="chrow" dita:longName="Choice Row">
@@ -989,9 +932,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="choption.element">
         <element name="choption" dita:longName="Choice Option">
@@ -1020,9 +960,6 @@ ORIGINAL CREATION DATE:
           <attribute name="specentry"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="chdesc.element">
         <element name="chdesc" dita:longName="Choice Description">
@@ -1048,9 +985,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="stepresult.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="stepresult.element">
         <element name="stepresult" dita:longName="Step Result">
@@ -1076,9 +1010,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="steptroubleshooting.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="steptroubleshooting.element">
         <element name="steptroubleshooting" dita:longName="Step Troubleshooting" dita:since="1.3">
@@ -1104,9 +1035,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="tasktroubleshooting.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="tasktroubleshooting.element">
         <element name="tasktroubleshooting" dita:longName="Task Troubleshooting" dita:since="1.3">
@@ -1132,9 +1060,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="result.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="result.element">
         <element name="result" dita:longName="Result">
@@ -1160,9 +1085,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="postreq.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="postreq.element">
         <element name="postreq" dita:longName="Post Requirements">

--- a/doctypes/rng/technicalContent/rng/taskMod.rng
+++ b/doctypes/rng/technicalContent/rng/taskMod.rng
@@ -1105,175 +1105,146 @@ ORIGINAL CREATION DATE:
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
 
     <define name="task.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/topic task/task "/>
       </optional>
     </define>
     <define name="taskbody.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/body task/taskbody "/>
       </optional>
     </define>
     <define name="steps.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ol task/steps "/>
       </optional>
     </define>
     <define name="steps-unordered.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ul task/steps-unordered "/>
       </optional>
     </define>
     <define name="stepsection.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/li task/stepsection "/>
       </optional>
     </define>
     <define name="step.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/li task/step "/>
       </optional>
     </define>
     <define name="cmd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ph task/cmd "/>
       </optional>
     </define>
     <define name="substeps.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ol task/substeps "/>
       </optional>
     </define>
     <define name="substep.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/li task/substep "/>
       </optional>
     </define>
     <define name="tutorialinfo.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/itemgroup task/tutorialinfo "/>
       </optional>
     </define>
     <define name="info.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/itemgroup task/info "/>
       </optional>
     </define>
     <define name="stepxmp.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/itemgroup task/stepxmp "/>
       </optional>
     </define>
     <define name="stepresult.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/itemgroup task/stepresult "/>
       </optional>
     </define>
     <define name="steptroubleshooting.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/itemgroup task/steptroubleshooting "/>
       </optional>
     </define>
     <define name="choices.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/ul task/choices "/>
       </optional>
     </define>
     <define name="choice.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/li task/choice "/>
       </optional>
     </define>
     <define name="result.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section task/result "/>
       </optional>
     </define>
     <define name="tasktroubleshooting.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section task/tasktroubleshooting "/>
       </optional>
     </define>
     <define name="prereq.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section task/prereq "/>
       </optional>
     </define>
     <define name="postreq.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section task/postreq "/>
       </optional>
     </define>
     <define name="context.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section task/context "/>
       </optional>
     </define>
     <define name="steps-informal.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section task/steps-informal "/>
       </optional>
     </define>
     <define name="choicetable.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/simpletable task/choicetable "/>
       </optional>
     </define>
     <define name="chhead.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/sthead task/chhead "/>
       </optional>
     </define>
     <define name="chrow.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/strow task/chrow "/>
       </optional>
     </define>
     <define name="choptionhd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry task/choptionhd "/>
       </optional>
     </define>
     <define name="chdeschd.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry task/chdeschd "/>
       </optional>
     </define>
     <define name="choption.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry task/choption "/>
       </optional>
     </define>
     <define name="chdesc.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/stentry task/chdesc "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/taskreqDomain.rng
+++ b/doctypes/rng/technicalContent/rng/taskreqDomain.rng
@@ -849,157 +849,131 @@ ORIGINAL CREATION DATE:
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="prelreqs.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/section task/prereq taskreq-d/prelreqs "/>
       </optional>
     </define>
     <define name="closereqs.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/section task/postreq taskreq-d/closereqs "/>
       </optional>
     </define>
     <define name="reqconds.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ul task/ul taskreq-d/reqconds "/>
       </optional>
     </define>
     <define name="noconds.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/noconds "/>
       </optional>
     </define>
     <define name="reqcond.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/reqcond "/>
       </optional>
     </define>
     <define name="reqcontp.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/reqcontp "/>
       </optional>
     </define>
     <define name="reqpers.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ul task/ul taskreq-d/reqpers "/>
       </optional>
     </define>
     <define name="personnel.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/personnel "/>
       </optional>
     </define>
     <define name="perscat.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/perscat "/>
       </optional>
     </define>
     <define name="perskill.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/perskill "/>
       </optional>
     </define>
     <define name="esttime.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/esttime "/>
       </optional>
     </define>
     <define name="supequip.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/p task/p taskreq-d/supequip "/>
       </optional>
     </define>
     <define name="nosupeq.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data task/data taskreq-d/nosupeq "/>
       </optional>
     </define>
     <define name="supeqli.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ul task/ul taskreq-d/supeqli "/>
       </optional>
     </define>
     <define name="supequi.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/supequi "/>
       </optional>
     </define>
     <define name="supplies.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/p task/p taskreq-d/supplies "/>
       </optional>
     </define>
     <define name="nosupply.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data task/data taskreq-d/nosupply "/>
       </optional>
     </define>
     <define name="supplyli.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ul task/ul taskreq-d/supplyli "/>
       </optional>
     </define>
     <define name="supply.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/supply "/>
       </optional>
     </define>
     <define name="spares.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/p task/p taskreq-d/spares "/>
       </optional>
     </define>
     <define name="nospares.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data task/data taskreq-d/nospares "/>
       </optional>
     </define>
     <define name="sparesli.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ul task/ul taskreq-d/sparesli "/>
       </optional>
     </define>
     <define name="spare.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/spare "/>
       </optional>
     </define>
     <define name="safety.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ol task/ol taskreq-d/safety "/>
       </optional>
     </define>
     <define name="nosafety.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/nosafety "/>
       </optional>
     </define>
     <define name="safecond.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/li task/li taskreq-d/safecond "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/taskreqDomain.rng
+++ b/doctypes/rng/technicalContent/rng/taskreqDomain.rng
@@ -176,9 +176,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="prelreqs.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="prelreqs.element">
         <element name="prelreqs" dita:longName="Preliminary Requirements">
@@ -199,9 +196,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="closereqs.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="closereqs.element">
         <element name="closereqs" dita:longName="Closing Requirements">
@@ -236,9 +230,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="reqconds.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="reqconds.element">
         <element name="reqconds" dita:longName="Required Conditions">
@@ -260,9 +251,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="noconds.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="noconds.element">
         <element name="noconds" dita:longName="No Required Conditions">
@@ -286,9 +274,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="reqcond.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="reqcond.element">
         <element name="reqcond" dita:longName="Required Condition">
@@ -312,9 +297,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="reqcontp.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="reqcontp.element">
         <element name="reqcontp" dita:longName="Required Condition Technical Publication">
@@ -355,9 +337,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="reqpers.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="reqpers.element">
         <element name="reqpers" dita:longName="Required Persons">
@@ -381,9 +360,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="personnel.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="personnel.element">
         <element name="personnel" dita:longName="Personnel">
@@ -407,9 +383,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="perscat.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="perscat.element">
         <element name="perscat" dita:longName="Personnel Category">
@@ -433,9 +406,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="perskill.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="perskill.element">
         <element name="perskill" dita:longName="Personnel Skill Level">
@@ -459,9 +429,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="esttime.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="esttime.element">
         <element name="esttime" dita:longName="Estimated Time">
@@ -486,9 +453,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="supequip.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="supequip.element">
         <element name="supequip" dita:longName="Support Equipment">
@@ -551,9 +515,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="supeqli.element">
         <element name="supeqli" dita:longName="Support Equipment List">
@@ -577,9 +538,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="supequi.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="supequi.element">
         <element name="supequi" dita:longName="Support Equipment Item">
@@ -604,9 +562,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="supplies.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="supplies.element">
         <element name="supplies" dita:longName="Supplies">
@@ -669,9 +624,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="supplyli.element">
         <element name="supplyli" dita:longName="Supply List">
@@ -695,9 +647,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="supply.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="supply.element">
         <element name="supply" dita:longName="Supply Item">
@@ -722,9 +671,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="spares.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="spares.element">
         <element name="spares" dita:longName="Spares">
@@ -787,9 +733,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="sparesli.element">
         <element name="sparesli" dita:longName="Spare List">
@@ -813,9 +756,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="spare.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="spare.element">
         <element name="spare" dita:longName="Spare Item">
@@ -848,9 +788,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="safety.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="safety.element">
         <element name="safety" dita:longName="Safety Conditions">
@@ -872,9 +809,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="nosafety.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="nosafety.element">
         <element name="nosafety" dita:longName="No Safety Conditions">
@@ -898,9 +832,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="safecond.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="safecond.element">
         <element name="safecond" dita:longName="Safety Condition">

--- a/doctypes/rng/technicalContent/rng/topic.rng
+++ b/doctypes/rng/technicalContent/rng/topic.rng
@@ -92,7 +92,11 @@ ORIGINAL CREATION DATE:
                          (topic sw-d)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"
         />
       </optional>
     </define>
@@ -106,7 +110,12 @@ ORIGINAL CREATION DATE:
       </define>
     </include>  
     <include href="abbreviateDomain.rng"/>
+    <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+    <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/topic.rng
+++ b/doctypes/rng/technicalContent/rng/topic.rng
@@ -115,7 +115,6 @@ ORIGINAL CREATION DATE:
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/topic.rng
+++ b/doctypes/rng/technicalContent/rng/topic.rng
@@ -83,7 +83,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -111,7 +110,6 @@ ORIGINAL CREATION DATE:
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-    <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
     <include href="markupDomain.rng" dita:since="1.3"/>
     <include href="mathmlDomain.rng" dita:since="1.3"/>
     <include href="programmingDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/rng/troubleshooting.rng
@@ -94,7 +94,11 @@ ORIGINAL CREATION DATE:
                          (topic task)
                          (topic ui-d)
                          (topic ut-d)
-                         a(props deliveryTarget)"/>
+                         a(props audience)
+                         a(props deliveryTarget)
+                         a(props platform)
+                         a(props product)
+                         a(props otherprops)"/>
          </optional>
       </define>
 
@@ -113,7 +117,12 @@ ORIGINAL CREATION DATE:
          </define>
       </include>
       <include href="abbreviateDomain.rng"/>
+     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/rng/troubleshooting.rng
@@ -122,7 +122,6 @@ ORIGINAL CREATION DATE:
      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
       <include href="equationDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/rng/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/rng/troubleshooting.rng
@@ -82,7 +82,6 @@ ORIGINAL CREATION DATE:
                          (topic equation-d)
                          (topic hazard-d)
                          (topic hi-d)
-                         (topic indexing-d)
                          (topic markup-d xml-d)
                          (topic markup-d)
                          (topic mathml-d)
@@ -118,7 +117,6 @@ ORIGINAL CREATION DATE:
       <include href="equationDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
-      <include href="urn:oasis:names:tc:dita:rng:indexingDomain.rng:2.0"/>
       <include href="markupDomain.rng"/>
       <include href="mathmlDomain.rng"/>
       <include href="programmingDomain.rng"/>

--- a/doctypes/rng/technicalContent/rng/troubleshootingMod.rng
+++ b/doctypes/rng/technicalContent/rng/troubleshootingMod.rng
@@ -338,43 +338,36 @@ ORIGINAL CREATION DATE:
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="troubleshooting.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/topic troubleshooting/troubleshooting "/>
       </optional>
     </define>
     <define name="troublebody.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/body troubleshooting/troublebody "/>
       </optional>
     </define>
     <define name="troubleSolution.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/bodydiv troubleshooting/troubleSolution "/>
       </optional>
     </define>
     <define name="cause.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section troubleshooting/cause "/>
       </optional>
     </define>
     <define name="condition.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section troubleshooting/condition "/>
       </optional>
     </define>
     <define name="remedy.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/section troubleshooting/remedy "/>
       </optional>
     </define>
     <define name="responsibleParty.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="- topic/p troubleshooting/responsibleParty "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/troubleshootingMod.rng
+++ b/doctypes/rng/technicalContent/rng/troubleshootingMod.rng
@@ -204,9 +204,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="spectitle"/>
         </optional>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="cause.element">
         <element name="cause" dita:longName="Cause" dita:since="1.3">
@@ -233,9 +230,6 @@ ORIGINAL CREATION DATE:
         <ref name="univ-atts"/>
         <optional>
           <attribute name="spectitle"/>
-        </optional>
-        <optional>
-          <attribute name="outputclass"/>
         </optional>
       </define>
       <define name="condition.element">
@@ -272,9 +266,6 @@ ORIGINAL CREATION DATE:
           <attribute name="spectitle"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="remedy.element">
         <element name="remedy" dita:longName="Remedy" dita:since="1.3">
@@ -299,9 +290,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="responsibleParty.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="responsibleParty.element">
         <element name="responsibleParty" dita:longName="Responsible Party" dita:since="1.3">
@@ -331,9 +319,6 @@ ORIGINAL CREATION DATE:
       </define>
       <define name="troubleSolution.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="troubleSolution.element">
         <element name="troubleSolution" dita:longName="Trouble Solution" dita:since="1.3">

--- a/doctypes/rng/technicalContent/rng/uiDomain.rng
+++ b/doctypes/rng/technicalContent/rng/uiDomain.rng
@@ -118,9 +118,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="uicontrol.element">
         <element name="uicontrol" dita:longName="User Interface Control">
@@ -151,9 +148,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="wintitle.element">
         <element name="wintitle" dita:longName="Window Title">
@@ -181,9 +175,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="menucascade.element">
         <element name="menucascade" dita:longName="Menu Cascade">
@@ -215,9 +206,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="shortcut.element">
         <element name="shortcut" dita:longName="Short Cut">
@@ -256,9 +244,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="screen.element">
         <element name="screen" dita:longName="Text Screen Capture">

--- a/doctypes/rng/technicalContent/rng/uiDomain.rng
+++ b/doctypes/rng/technicalContent/rng/uiDomain.rng
@@ -261,31 +261,26 @@ ORIGINAL CREATION DATE:
   <div>
     <a:documentation>SPECIALIZATION ATTRIBUTE DECLARATIONS</a:documentation>
     <define name="menucascade.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph ui-d/menucascade "/>
       </optional>
     </define>
     <define name="screen.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/pre ui-d/screen "/>
       </optional>
     </define>
     <define name="shortcut.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword ui-d/shortcut "/>
       </optional>
     </define>
     <define name="uicontrol.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph ui-d/uicontrol "/>
       </optional>
     </define>
     <define name="wintitle.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword ui-d/wintitle "/>
       </optional>

--- a/doctypes/rng/technicalContent/rng/xmlDomain.rng
+++ b/doctypes/rng/technicalContent/rng/xmlDomain.rng
@@ -64,9 +64,6 @@
       </define>
       <define name="numcharref.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="numcharref.element">
         <element name="numcharref" dita:longName="Numeric character reference (&amp;#10;, &amp;#x0a;)" dita:since="1.3">
@@ -92,9 +89,6 @@
       </define>
       <define name="parameterentity.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="parameterentity.element">
         <element name="parameterentity" dita:longName="Parameter entity reference (%p.content;)" dita:since="1.3">
@@ -121,9 +115,6 @@
       </define>
       <define name="textentity.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="textentity.element">
         <element name="textentity" dita:longName="Text entity (&amp;prodname;)"
@@ -151,9 +142,6 @@
       </define>
       <define name="xmlatt.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="xmlatt.element">
         <element name="xmlatt" dita:longName="XML attribute" dita:since="1.3">
@@ -180,9 +168,6 @@
       </define>
       <define name="xmlelement.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="xmlelement.element">
         <element name="xmlelement" dita:longName="XML element" dita:since="1.3">
@@ -209,9 +194,6 @@
       </define>
       <define name="xmlnsname.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="xmlnsname.element">
         <element name="xmlnsname" dita:longName="XML namespace name (aka &quot;namespace URI&quot;)" dita:since="1.3">
@@ -239,9 +221,6 @@
       </define>
       <define name="xmlpi.attributes">
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="xmlpi.element">
         <element name="xmlpi" dita:longName="XML processing instruction (PI)" dita:since="1.3">

--- a/doctypes/rng/technicalContent/rng/xmlDomain.rng
+++ b/doctypes/rng/technicalContent/rng/xmlDomain.rng
@@ -238,43 +238,36 @@
   <div>
     <a:documentation> Specialization attributes. Global attributes and class defaults </a:documentation>
     <define name="numcharref.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword markup-d/markupname xml-d/numcharref "/>
       </optional>
     </define>
     <define name="parameterentity.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword markup-d/markupname xml-d/parameterentity "/>
       </optional>
     </define>
     <define name="textentity.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword markup-d/markupname xml-d/textentity "/>
       </optional>
     </define>
     <define name="xmlatt.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword markup-d/markupname xml-d/xmlatt "/>
       </optional>
     </define>
     <define name="xmlelement.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword markup-d/markupname xml-d/xmlelement "/>
       </optional>
     </define>
     <define name="xmlnsname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword markup-d/markupname xml-d/xmlnsname "/>
       </optional>
     </define>
     <define name="xmlpi.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/keyword markup-d/markupname xml-d/xmlpi "/>
       </optional>

--- a/doctypes/rng/xnal/rng/xnalDomain.rng
+++ b/doctypes/rng/xnal/rng/xnalDomain.rng
@@ -888,157 +888,131 @@ ORIGINAL CREATION DATE:
   <div>
     <a:documentation> SPECIALIZATION ATTRIBUTE DECLARATIONS </a:documentation>
     <define name="addressdetails.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/addressdetails "/>
       </optional>
     </define>
     <define name="administrativearea.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/administrativearea "/>
       </optional>
     </define>
     <define name="authorinformation.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/author xnal-d/authorinformation "/>
       </optional>
     </define>
     <define name="contactnumber.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/contactnumber "/>
       </optional>
     </define>
     <define name="contactnumbers.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/contactnumbers "/>
       </optional>
     </define>
     <define name="country.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/country "/>
       </optional>
     </define>
     <define name="emailaddress.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/emailaddress "/>
       </optional>
     </define>
     <define name="emailaddresses.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/emailaddresses "/>
       </optional>
     </define>
     <define name="firstname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/firstname "/>
       </optional>
     </define>
     <define name="generationidentifier.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/generationidentifier "/>
       </optional>
     </define>
     <define name="honorific.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/honorific "/>
       </optional>
     </define>
     <define name="lastname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/lastname "/>
       </optional>
     </define>
     <define name="locality.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/locality "/>
       </optional>
     </define>
     <define name="localityname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/localityname "/>
       </optional>
     </define>
     <define name="middlename.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/middlename "/>
       </optional>
     </define>
     <define name="namedetails.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/namedetails "/>
       </optional>
     </define>
     <define name="organizationinfo.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/organizationinfo "/>
       </optional>
     </define>
     <define name="organizationname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/organizationname "/>
       </optional>
     </define>
     <define name="organizationnamedetails.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/organizationnamedetails "/>
       </optional>
     </define>
     <define name="otherinfo.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/otherinfo "/>
       </optional>
     </define>
     <define name="personinfo.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/personinfo "/>
       </optional>
     </define>
     <define name="personname.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/personname "/>
       </optional>
     </define>
     <define name="postalcode.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/postalcode "/>
       </optional>
     </define>
     <define name="thoroughfare.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/ph xnal-d/thoroughfare "/>
       </optional>
     </define>
     <define name="url.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/url "/>
       </optional>
     </define>
     <define name="urls.attlist" combine="interleave">
-      <ref name="global-atts"/>
       <optional>
         <attribute name="class" a:defaultValue="+ topic/data xnal-d/urls "/>
       </optional>

--- a/doctypes/rng/xnal/rng/xnalDomain.rng
+++ b/doctypes/rng/xnal/rng/xnalDomain.rng
@@ -238,9 +238,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="organizationnamedetails.element">
         <element name="organizationnamedetails" dita:longName="Organization Details">
@@ -267,9 +264,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="organizationname.element">
         <element name="organizationname" dita:longName="Organization Name">
@@ -498,9 +492,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="addressdetails.element">
         <element name="addressdetails" dita:longName="Address Details">
@@ -531,9 +522,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="locality.element">
         <element name="locality" dita:longName="Locality">
@@ -560,9 +548,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="localityname.element">
         <element name="localityname" dita:longName="Locality Name">
@@ -589,9 +574,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="administrativearea.element">
         <element name="administrativearea" dita:longName="Administrative Area">
@@ -618,9 +600,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="thoroughfare.element">
         <element name="thoroughfare" dita:longName="Thoroughfare">
@@ -651,9 +630,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="postalcode.element">
         <element name="postalcode" dita:longName="Postal Code">
@@ -684,9 +660,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <ref name="univ-atts"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
       </define>
       <define name="country.element">
         <element name="country" dita:longName="Country">


### PR DESCRIPTION
Brings both DTD and RNG up to date for 2.0, and removes any of the deprecated items that would break parsing. Probably doesn't get everything. For example -- I removed `@navtitle` from the chapter element, which was invalid DITA (it's gone from the base so can't be on the specialization), but would have been fine from an XML perspective. There could be similar attributes but I got everything that I remembered offhand. Also fixed all references that would have broken parsing, like references to obsolete domains / local declaration of `@outputclass` that is now in the universal attribute set.