### PR TITLE
Remove deprecated / obsolete items

### DIFF
--- a/doctypes/dtd/bookmap/dtd/bookmap.mod
+++ b/doctypes/dtd/bookmap/dtd/bookmap.mod
@@ -225,9 +225,6 @@
               "keyref
                           CDATA
                                     #IMPLIED
-               query
-                          CDATA
-                                    #IMPLIED
                %topicref-atts;
                %univ-atts;"
 >
@@ -246,9 +243,6 @@
 >
 <!ENTITY % backmatter.attributes
               "keyref
-                          CDATA
-                                    #IMPLIED
-               query
                           CDATA
                                     #IMPLIED
                %topicref-atts;

--- a/doctypes/dtd/technicalContent/dtd/glossentry.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.mod
@@ -386,9 +386,6 @@
                keyref
                           CDATA
                                     #IMPLIED
-               longdescref
-                          CDATA
-                                    #IMPLIED
                height
                           NMTOKEN
                                     #IMPLIED

--- a/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
@@ -55,9 +55,6 @@
                keys
                           CDATA
                                     #REQUIRED
-               query
-                          CDATA
-                                    #IMPLIED
                copy-to
                           CDATA
                                     #IMPLIED

--- a/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/glossrefDomain.mod
@@ -97,12 +97,6 @@
                            yes |
                            -dita-use-conref-target)
                                     'no'
-               print
-                          (no |
-                           printonly |
-                           yes |
-                           -dita-use-conref-target)
-                                    'no'
                search
                           (no |
                            yes |

--- a/doctypes/dtd/technicalContent/dtd/reference.mod
+++ b/doctypes/dtd/technicalContent/dtd/reference.mod
@@ -170,9 +170,6 @@
                keycol
                           NMTOKEN
                                     #IMPLIED
-               refcols
-                          NMTOKENS
-                                    #IMPLIED
                spectitle
                           CDATA
                                     #IMPLIED

--- a/doctypes/dtd/technicalContent/dtd/task.mod
+++ b/doctypes/dtd/technicalContent/dtd/task.mod
@@ -358,9 +358,6 @@
                keycol
                           NMTOKEN
                                     '1'
-               refcols
-                          NMTOKENS
-                                    #IMPLIED
                spectitle
                           CDATA
                                     #IMPLIED

--- a/doctypes/rng/bookmap/rng/bookmapMod.rng
+++ b/doctypes/rng/bookmap/rng/bookmapMod.rng
@@ -448,9 +448,6 @@ ORIGINAL CREATION DATE:
         <optional>
           <attribute name="keyref"/>
         </optional>
-        <optional>
-          <attribute name="query"/>
-        </optional>
         <ref name="topicref-atts"/>
         <ref name="univ-atts"/>
       </define>
@@ -484,9 +481,6 @@ ORIGINAL CREATION DATE:
       <define name="backmatter.attributes">
         <optional>
           <attribute name="keyref"/>
-        </optional>
-        <optional>
-          <attribute name="query"/>
         </optional>
         <ref name="topicref-atts"/>
         <ref name="univ-atts"/>

--- a/doctypes/rng/technicalContent/rng/glossentryMod.rng
+++ b/doctypes/rng/technicalContent/rng/glossentryMod.rng
@@ -638,9 +638,6 @@ ORIGINAL CREATION DATE:
           <attribute name="keyref"/>
         </optional>
         <optional>
-          <attribute name="longdescref"/>
-        </optional>
-        <optional>
           <attribute name="height">
             <data type="NMTOKEN"/>
           </attribute>

--- a/doctypes/rng/technicalContent/rng/glossrefDomain.rng
+++ b/doctypes/rng/technicalContent/rng/glossrefDomain.rng
@@ -147,16 +147,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <optional>
-          <attribute name="print" a:defaultValue="no">
-            <choice>
-              <value>no</value>
-              <value>printonly</value>
-              <value>yes</value>
-              <value>-dita-use-conref-target</value>
-            </choice>
-          </attribute>
-        </optional>
-        <optional>
           <attribute name="search" a:defaultValue="no">
             <choice>
               <value>no</value>

--- a/doctypes/rng/technicalContent/rng/glossrefDomain.rng
+++ b/doctypes/rng/technicalContent/rng/glossrefDomain.rng
@@ -85,9 +85,6 @@ ORIGINAL CREATION DATE:
         </optional>
         <attribute name="keys"/>
         <optional>
-          <attribute name="query"/>
-        </optional>
-        <optional>
           <attribute name="copy-to"/>
         </optional>
         <optional>

--- a/doctypes/rng/technicalContent/rng/referenceMod.rng
+++ b/doctypes/rng/technicalContent/rng/referenceMod.rng
@@ -296,11 +296,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <optional>
-          <attribute name="refcols">
-            <data type="NMTOKENS"/>
-          </attribute>
-        </optional>
-        <optional>
           <attribute name="spectitle"/>
         </optional>
         <ref name="display-atts"/>

--- a/doctypes/rng/technicalContent/rng/taskMod.rng
+++ b/doctypes/rng/technicalContent/rng/taskMod.rng
@@ -709,11 +709,6 @@ ORIGINAL CREATION DATE:
           </attribute>
         </optional>
         <optional>
-          <attribute name="refcols">
-            <data type="NMTOKENS"/>
-          </attribute>
-        </optional>
-        <optional>
           <attribute name="spectitle"/>
         </optional>
         <ref name="display-atts"/>


### PR DESCRIPTION
Brings tech comm document types up to date with https://github.com/oasis-tcs/dita/issues/36 for removing deprecated / obsolete items from the grammar files.