### PR TITLE
Make outputclass universal

### DIFF
--- a/doctypes/dtd/bookmap/dtd/bookmap.mod
+++ b/doctypes/dtd/bookmap/dtd/bookmap.mod
@@ -1028,7 +1028,10 @@
                %topicref-atts;
                %id-atts;
                %select-atts;
-               %localization-atts;"
+               %localization-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED"
 >
 <!ELEMENT  booklists %booklists.content;>
 <!ATTLIST  booklists %booklists.attributes;>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Updates tech comm doctypes for oasis-tcs/dita#17

Most had already been updated, but found one element still missing `@outputclass`