### PR TITLE
Update tech comm topics based on introduction of include element

### DIFF
--- a/doctypes/dtd/bookmap/dtd/bookmap.dtd
+++ b/doctypes/dtd/bookmap/dtd/bookmap.dtd
@@ -177,8 +177,10 @@
                          %ui-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/classificationMap/classifyMap.dtd
+++ b/doctypes/dtd/classificationMap/classifyMap.dtd
@@ -171,9 +171,11 @@
                          %ui-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig;
                         ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
+                        ">                        
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">

--- a/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
+++ b/doctypes/dtd/machineryIndustry/dtd/machineryTask.dtd
@@ -129,8 +129,8 @@
                          %hi-d-ph; |
                          %ui-d-ph;
                         ">
-<!ENTITY % fig          "fig |
-                         %ut-d-fig;
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/concept.dtd
+++ b/doctypes/dtd/technicalContent/dtd/concept.dtd
@@ -176,9 +176,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/dtd/ditabase.dtd
@@ -206,9 +206,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/generalTask.dtd
+++ b/doctypes/dtd/technicalContent/dtd/generalTask.dtd
@@ -172,9 +172,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/glossentry.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossentry.dtd
@@ -181,9 +181,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
+++ b/doctypes/dtd/technicalContent/dtd/glossgroup.dtd
@@ -177,9 +177,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/map.dtd
+++ b/doctypes/dtd/technicalContent/dtd/map.dtd
@@ -179,8 +179,10 @@
                          %ui-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
@@ -49,6 +49,9 @@
                format
                           CDATA
                                     'mml'
+               parse
+                          CDATA
+                                    'xml'
                scope
                           (external |
                            local |
@@ -81,7 +84,7 @@
 <!-- ============================================================= -->
   
 <!ATTLIST  mathml       class CDATA "+ topic/foreign mathml-d/mathml ">
-<!ATTLIST  mathmlref    class CDATA "+ topic/xref mathml-d/mathmlref ">
+<!ATTLIST  mathmlref    class CDATA "+ topic/include mathml-d/mathmlref ">
 
 <!-- ================== End of DITA MathML Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
@@ -58,6 +58,9 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
+               encoding
+                          CDATA
+                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  mathmlref %mathmlref.content;>

--- a/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
@@ -167,6 +167,9 @@
                            peer |
                            -dita-use-conref-target)
                                     #IMPLIED
+               encoding
+                          CDATA
+                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  coderef %coderef.content;>

--- a/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
@@ -158,6 +158,9 @@
                format
                           CDATA
                                     #IMPLIED
+               parse
+                          CDATA
+                                    'text'
                scope
                           (external |
                            local |
@@ -595,7 +598,7 @@
 <!ATTLIST  apiname      class CDATA "+ topic/keyword pr-d/apiname ">
 <!ATTLIST  codeblock    class CDATA "+ topic/pre pr-d/codeblock ">
 <!ATTLIST  codeph       class CDATA "+ topic/ph pr-d/codeph ">
-<!ATTLIST  coderef      class CDATA "+ topic/xref pr-d/coderef ">
+<!ATTLIST  coderef      class CDATA "+ topic/include pr-d/coderef ">
 <!ATTLIST  delim        class CDATA "+ topic/ph pr-d/delim ">
 <!ATTLIST  fragment     class CDATA "+ topic/figgroup pr-d/fragment ">
 <!ATTLIST  fragref      class CDATA "+ topic/xref pr-d/fragref ">

--- a/doctypes/dtd/technicalContent/dtd/reference.dtd
+++ b/doctypes/dtd/technicalContent/dtd/reference.dtd
@@ -178,9 +178,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/svgDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/svgDomain.mod
@@ -50,6 +50,9 @@
                format
                           CDATA
                                     'svg'
+               parse
+                          CDATA
+                                    'xml'
                %univ-atts;"
 >
 <!ELEMENT  svgref %svgref.content;>
@@ -62,7 +65,7 @@
 <!-- ============================================================= -->
   
 <!ATTLIST  svg-container class CDATA "+ topic/foreign svg-d/svg-container ">
-<!ATTLIST  svgref       class CDATA "+ topic/xref svg-d/svgref ">
+<!ATTLIST  svgref       class CDATA "+ topic/include svg-d/svgref ">
 
 <!-- ================== End of DITA SVG Domain ==================== -->
  

--- a/doctypes/dtd/technicalContent/dtd/svgDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/svgDomain.mod
@@ -53,6 +53,9 @@
                parse
                           CDATA
                                     'xml'
+               encoding
+                          CDATA
+                                    #IMPLIED
                %univ-atts;"
 >
 <!ELEMENT  svgref %svgref.content;>

--- a/doctypes/dtd/technicalContent/dtd/task.dtd
+++ b/doctypes/dtd/technicalContent/dtd/task.dtd
@@ -176,9 +176,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/topic.dtd
+++ b/doctypes/dtd/technicalContent/dtd/topic.dtd
@@ -169,9 +169,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
+++ b/doctypes/dtd/technicalContent/dtd/troubleshooting.dtd
@@ -173,9 +173,11 @@
                          %equation-d-ph;
                         ">
 <!ENTITY % fig          "fig |
-                         %ut-d-fig; |
                          %pr-d-fig; |
                          %equation-d-fig;
+                        ">
+<!ENTITY % div          "div |
+                         %ut-d-div;
                         ">
 <!ENTITY % data         "data |
                          %ut-d-data;

--- a/doctypes/rng/technicalContent/rng/mathmlDomain.rng
+++ b/doctypes/rng/technicalContent/rng/mathmlDomain.rng
@@ -96,6 +96,9 @@ All Rights Reserved.
           <attribute name="format" a:defaultValue="mml"/>
         </optional>
         <optional>
+          <attribute name="parse" a:defaultValue="xml"/>
+        </optional>
+        <optional>
           <attribute name="scope">
             <choice>
               <value>external</value>
@@ -221,7 +224,7 @@ elements
 
     <define name="mathmlref.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="+ topic/xref mathml-d/mathmlref "/>
+        <attribute name="class" a:defaultValue="+ topic/include mathml-d/mathmlref "/>
       </optional>
     </define>
   </div>

--- a/doctypes/rng/technicalContent/rng/mathmlDomain.rng
+++ b/doctypes/rng/technicalContent/rng/mathmlDomain.rng
@@ -99,6 +99,9 @@ All Rights Reserved.
           <attribute name="parse" a:defaultValue="xml"/>
         </optional>
         <optional>
+          <attribute name="encoding"/>
+        </optional>
+        <optional>
           <attribute name="scope">
             <choice>
               <value>external</value>

--- a/doctypes/rng/technicalContent/rng/programmingDomain.rng
+++ b/doctypes/rng/technicalContent/rng/programmingDomain.rng
@@ -301,6 +301,9 @@ ORIGINAL CREATION DATE:
           <attribute name="format"/>
         </optional>
         <optional>
+          <attribute name="parse" a:defaultValue="text"/>
+        </optional>
+        <optional>
           <attribute name="scope">
             <choice>
               <value>external</value>
@@ -1153,7 +1156,7 @@ ORIGINAL CREATION DATE:
     </define>
     <define name="coderef.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="+ topic/xref pr-d/coderef "/>
+        <attribute name="class" a:defaultValue="+ topic/include pr-d/coderef "/>
       </optional>
     </define>
     <define name="delim.attlist" combine="interleave">

--- a/doctypes/rng/technicalContent/rng/programmingDomain.rng
+++ b/doctypes/rng/technicalContent/rng/programmingDomain.rng
@@ -304,6 +304,9 @@ ORIGINAL CREATION DATE:
           <attribute name="parse" a:defaultValue="text"/>
         </optional>
         <optional>
+          <attribute name="encoding"/>
+        </optional>
+        <optional>
           <attribute name="scope">
             <choice>
               <value>external</value>

--- a/doctypes/rng/technicalContent/rng/svgDomain.rng
+++ b/doctypes/rng/technicalContent/rng/svgDomain.rng
@@ -98,6 +98,9 @@ DITA SVG Domain
         <optional>
           <attribute name="format" a:defaultValue="svg"/>
         </optional>
+        <optional>
+          <attribute name="parse" a:defaultValue="xml"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="svgref.element">
@@ -122,7 +125,7 @@ DITA SVG Domain
     </define>
     <define name="svgref.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="+ topic/xref svg-d/svgref "/>
+        <attribute name="class" a:defaultValue="+ topic/include svg-d/svgref "/>
       </optional>
     </define>
   </div>

--- a/doctypes/rng/technicalContent/rng/svgDomain.rng
+++ b/doctypes/rng/technicalContent/rng/svgDomain.rng
@@ -101,6 +101,9 @@ DITA SVG Domain
         <optional>
           <attribute name="parse" a:defaultValue="xml"/>
         </optional>
+        <optional>
+          <attribute name="encoding"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="svgref.element">

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -30,9 +30,9 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>The <xmlelement>coderef</xmlelement> is specialized from <xmlelement>xref</xmlelement>. It
+      <p>The <xmlelement>coderef</xmlelement> is specialized from <xmlelement>include</xmlelement>. It
         is defined in the programming domain module.</p>
-      <!--<p>+ topic/xref pr-d/coderef</p>-->
+      <!--<p>+ topic/include pr-d/coderef</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -37,8 +37,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <p id="xref-attributes">The following attributes are available on this element: <xref
-          keyref="attributes-universal"/>, <xref keyref="attributes-linkRelationship"/>, and <xref
-          keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+keyref="attributes-universal"/>, <xref keyref="attributes-includeElement/encoding"
+><xmlatt>encoding</xmlatt></xref>, <xref keyref="attributes-includeElement/parse"
+><xmlatt>parse</xmlatt></xref> (with a default value of "text"), <xref
+keyref="attributes-linkRelationship"/>, and <xref keyref="attributes-keyref"
+><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -49,7 +49,7 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/xref mathml-d/mathmlref</p>
+      <p>+ topic/include mathml-d/mathmlref</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -54,10 +54,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"
-        />, <xref keyref="commonAttributes/outputclass"/>, and <xref keyref="thekeyrefattribute"
-            ><xmlatt>keyref</xmlatt></xref>. This element also uses <xmlatt>href</xmlatt>,
-          <xmlatt>scope</xmlatt>, and a narrowed definition of <xmlatt>format</xmlatt> (given below)
-        from <xref keyref="linkRelationshipAttributes"/>.</p>
+/>, <xref keyref="attributes-includeElement/encoding"><xmlatt>encoding</xmlatt></xref>, <xref
+keyref="attributes-includeElement/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
+"xml"), and <xref keyref="thekeyrefattribute"><xmlatt>keyref</xmlatt></xref>. This element also uses
+<xmlatt>href</xmlatt>, <xmlatt>scope</xmlatt>, and a narrowed definition of <xmlatt>format</xmlatt>
+(given below) from <xref keyref="linkRelationshipAttributes"/>.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>format</xmlatt></dt>

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -45,7 +45,7 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/xref svg-d/svgref</p>
+      <p>+ topic/include svg-d/svgref</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -50,10 +50,11 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"
-        />, <xref keyref="commonAttributes/outputclass"/>, and <xref keyref="thekeyrefattribute"
-            ><xmlatt>keyref</xmlatt></xref>. This element also uses <xref
-          keyref="linkRelationshipAttributes"/>, with narrowed definitions of <xmlatt>href</xmlatt>
-        and <xmlatt>format</xmlatt> (given below).</p>
+/>, <xref keyref="attributes-includeElement/encoding"><xmlatt>encoding</xmlatt></xref>, <xref
+keyref="attributes-includeElement/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
+"xml"), and <xref keyref="thekeyrefattribute"><xmlatt>keyref</xmlatt></xref>. This element also uses
+<xref keyref="linkRelationshipAttributes"/>, with narrowed definitions of <xmlatt>href</xmlatt> and
+<xmlatt>format</xmlatt> (given below).</p>
       <dl>
         <dlentry>
           <dt><xmlatt>href</xmlatt></dt>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -3995,7 +3995,7 @@ for this?</draft-comment>-->
         </strow>
         <strow>
           <stentry><xmlelement>mathmlref</xmlelement></stentry>
-          <stentry><xmlelement>xref</xmlelement></stentry>
+          <stentry><xmlelement>include</xmlelement></stentry>
           <stentry>yes</stentry>
           <stentry>inline</stentry>
           <stentry>N/A (empty)</stentry>
@@ -4027,7 +4027,7 @@ for this?</draft-comment>-->
         </strow>
         <strow>
           <stentry><xmlelement>svgref</xmlelement></stentry>
-          <stentry><xmlelement>xref</xmlelement></stentry>
+          <stentry><xmlelement>include</xmlelement></stentry>
           <stentry>yes</stentry>
           <stentry>inline</stentry>
           <stentry>N/A (empty)</stentry>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -2463,7 +2463,7 @@ for this?</draft-comment>-->
         </strow>
         <strow>
           <stentry><xmlelement>coderef</xmlelement> <i>(new in DITA 1.2)</i></stentry>
-          <stentry><xmlelement>xref</xmlelement></stentry>
+          <stentry><xmlelement>include</xmlelement></stentry>
           <stentry>yes</stentry>
           <stentry>inline</stentry>
           <stentry>N/A <i>(empty element)</i></stentry>


### PR DESCRIPTION
Updates to match base changes from oasis-tcs/dita#8

- [X] Update grammar files for new class attribute base for `coderef`, `mathmlref`, `svgref`
- [X] Update grammar files to add `@parse` to same elements
- [X] Update grammar files to add `@encoding` to same elements (missing from original proposal)
- [X] Update langref topics for those three to show the new inheritance
- [X] Update translation tables, which repeat that information
- [X] Update langref topics for those three to add `@encoding` and to add `@parse` as a valid attribute with default value

Open question, not addressed by the proposal: should any or all of these now include the `<fallback>` child element? If so, that will also require changes to the translation table, which currently states that the element is empty.