### PR TITLE
Bring programming domain topics up to date, fix conref errors

### DIFF
--- a/specification/langRef/technicalContent/apiname.dita
+++ b/specification/langRef/technicalContent/apiname.dita
@@ -17,10 +17,6 @@
       </metadata>
    </prolog>
    <refbody>
-      <section id="usage-information">
-         <title>Usage information</title>
-         <p>This element is part of the programming domain.</p>
-      </section>
       <section id="specialization-hierarchy"
             ><title>Specialization hierarchy</title>
          <p>The <xmlelement>apiname</xmlelement> is specialized from

--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
       <p>Processors <term outputclass="RFC-2119">SHOULD</term> preserve line the breaks and spaces

--- a/specification/langRef/technicalContent/codeph.dita
+++ b/specification/langRef/technicalContent/codeph.dita
@@ -14,10 +14,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>codeph</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -17,10 +17,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
       <p>When evaluated, the <xmlelement>coderef</xmlelement> element causes the target code to be

--- a/specification/langRef/technicalContent/delim.dita
+++ b/specification/langRef/technicalContent/delim.dita
@@ -19,7 +19,6 @@
       <title>Usage information</title>
       <p>Typical delimiter characters are the parenthesis, comma, tab, vertical bar or other special
         characters.</p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/fragment.dita
+++ b/specification/langRef/technicalContent/fragment.dita
@@ -19,7 +19,6 @@
       <title>Usage information</title>
       <p>The <xmlelement>fragment</xmlelement> element allows breaking out logical chunks of a large
         syntax diagram into named fragments. </p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/fragref.dita
+++ b/specification/langRef/technicalContent/fragref.dita
@@ -16,14 +16,12 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p><ph conref="apiname.dita#apiname/progdomainelement"/></p>
-    </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/xref pr-d/fragref</p>
-    </section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>fragref</xmlelement> is specialized from <xmlelement>xref</xmlelement>. It is
+defined in the programming domain module.</p>
+<!--<p>+ topic/xref pr-d/fragref</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"

--- a/specification/langRef/technicalContent/groupchoice.dita
+++ b/specification/langRef/technicalContent/groupchoice.dita
@@ -19,7 +19,6 @@
       <p>A group is a logical set of pieces of syntax that go together. A group choice specifies
         that the user must make a choice about which part of the syntax to use. Groups are often
         nested.</p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/groupcomp.dita
+++ b/specification/langRef/technicalContent/groupcomp.dita
@@ -20,14 +20,15 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p>A group is a logical set of pieces of syntax that go together. The group composite means
-        that the items that make up the syntax diagram will be formatted close together rather than
-        being separated by a horizontal or vertical line, which is the usual formatting method. <ph
-          conref="apiname.dita#apiname/progdomainelement"/></p>
+that the items that make up the syntax diagram will be formatted close together rather than being
+separated by a horizontal or vertical line, which is the usual formatting method.</p>
     </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/figgroup pr-d/groupcomp</p>
-    </section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>groupcomp</xmlelement> is specialized from <xmlelement>figgroup</xmlelement>. It
+is defined in the programming domain module.</p>
+<!--<p>+ topic/figgroup pr-d/groupcomp</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv conkeyref="conref-attribute/syntaxelement-update-importance"/></section>

--- a/specification/langRef/technicalContent/groupseq.dita
+++ b/specification/langRef/technicalContent/groupseq.dita
@@ -21,7 +21,6 @@
         definition, groups of keywords, delimiters and other syntax units act as a combined unit,
         and they occur in a specific sequence, as delimited by the <xmlelement>groupseq</xmlelement>
         element. </p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/kwd.dita
+++ b/specification/langRef/technicalContent/kwd.dita
@@ -18,7 +18,6 @@
       <title>Usage information</title>
       <p>A keyword is typed or output, by the user or application, exactly as specified in the
         syntax diagram or phrase.</p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/oper.dita
+++ b/specification/langRef/technicalContent/oper.dita
@@ -18,7 +18,6 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p>Typical operators are equals (=), plus (+) or multiply (*). </p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/option.dita
+++ b/specification/langRef/technicalContent/option.dita
@@ -18,10 +18,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>option</xmlelement> is specialized from <xmlelement>keyword</xmlelement>.

--- a/specification/langRef/technicalContent/parml.dita
+++ b/specification/langRef/technicalContent/parml.dita
@@ -18,10 +18,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>parml</xmlelement> is specialized from <xmlelement>dl</xmlelement>. It is

--- a/specification/langRef/technicalContent/parmname.dita
+++ b/specification/langRef/technicalContent/parmname.dita
@@ -17,10 +17,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>parmname</xmlelement> is specialized from <xmlelement>keyword</xmlelement>.

--- a/specification/langRef/technicalContent/pd.dita
+++ b/specification/langRef/technicalContent/pd.dita
@@ -16,14 +16,12 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p><ph conref="apiname.dita#apiname/progdomainelement"/></p>
-    </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/dd pr-d/pd</p>
-    </section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>pd</xmlelement> is specialized from <xmlelement>dd</xmlelement>. It is defined in
+the programming domain module.</p>
+<!--<p>+ topic/dd pr-d/pd</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>

--- a/specification/langRef/technicalContent/plentry.dita
+++ b/specification/langRef/technicalContent/plentry.dita
@@ -17,14 +17,12 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p><ph conref="apiname.dita#apiname/progdomainelement"/></p>
-    </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/dlentry pr-d/plentry</p>
-    </section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>plentry</xmlelement> is specialized from <xmlelement>dlentry</xmlelement>. It is
+defined in the programming domain module.</p>
+<!--<p>+ topic/dlentry pr-d/plentry</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>

--- a/specification/langRef/technicalContent/pt.dita
+++ b/specification/langRef/technicalContent/pt.dita
@@ -4,7 +4,7 @@
 <reference id="pt" xml:lang="en-us">
   <title><xmlelement>pt</xmlelement></title>
   <shortdesc>The <xmlelement>pt</xmlelement> element specifies a parameter term within a parameter
-    list entry. <ph conref="apiname.dita#apiname/progdomainelement"/></shortdesc>
+list entry.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -16,14 +16,12 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p><ph conref="apiname.dita#apiname/progdomainelement"/></p>
-    </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/dt pr-d/pt</p>
-    </section>
+<section>
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>pt</xmlelement> is specialized from <xmlelement>dt</xmlelement>. It is defined in
+the programming domain module.</p>
+<!--<p>+ topic/dt pr-d/pt</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>

--- a/specification/langRef/technicalContent/repsep.dita
+++ b/specification/langRef/technicalContent/repsep.dita
@@ -19,7 +19,6 @@
       <p>If the <xmlelement>repsep</xmlelement> element contains a separator character such as a
         plus (+), this indicates that the character must be used between repetitions of the syntax
         elements. </p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/sep.dita
+++ b/specification/langRef/technicalContent/sep.dita
@@ -18,7 +18,6 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p>The separator occurs between keywords, operators or groups in a syntax definition.</p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/synblk.dita
+++ b/specification/langRef/technicalContent/synblk.dita
@@ -15,15 +15,12 @@
     </metadata>
   </prolog>
   <refbody>
-<section id="usage-information">
-         <title>Usage information</title>
-         <p><ph conref="apiname.dita#apiname/progdomainelement"
-    /></p>
-      </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/figgroup pr-d/synblk</p>
-    </section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>synblk</xmlelement> is specialized from <xmlelement>figgroup</xmlelement>. It is
+defined in the programming domain module.</p>
+<!--<p>+ topic/figgroup pr-d/synblk</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>

--- a/specification/langRef/technicalContent/synnote.dita
+++ b/specification/langRef/technicalContent/synnote.dita
@@ -20,13 +20,19 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p>The syntax note explains aspects of the syntax that cannot be expressed in the markup
-        itself. The note will appear at the bottom of the syntax diagram instead of at the bottom of
-        the page. <ph conref="apiname.dita#apiname/progdomainelement"/></p>
+itself.</p>
     </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/fn pr-d/synnote</p>
-    </section>
+<section id="rendering-expectations">
+<title>Rendering expectations</title>
+<p>The note will appear at the bottom of the syntax diagram instead of at the bottom of the
+page.</p>
+</section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>synnote</xmlelement> is specialized from <xmlelement>fn</xmlelement>. It is
+defined in the programming domain module.</p>
+<!--<p>+ topic/fn pr-d/synnote</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <sectiondiv conkeyref="conref-attribute/fn-attributes"/></section>

--- a/specification/langRef/technicalContent/synnoteref.dita
+++ b/specification/langRef/technicalContent/synnoteref.dita
@@ -18,13 +18,14 @@
   <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The same notation can be used in more than one syntax definition. <ph
-          conref="apiname.dita#apiname/progdomainelement"/></p>
+      <p>The same notation can be used in more than one syntax definition.</p>
     </section>
-    <section id="specialization-hierarchy">
-      <title>Specialization hierarchy</title>
-      <p>+ topic/xref pr-d/synnoteref</p>
-    </section>
+<section id="specialization-hierarchy">
+<title>Specialization hierarchy</title>
+<p>The <xmlelement>synnoteref</xmlelement> is specialized from <xmlelement>xref</xmlelement>. It is
+defined in the programming domain module.</p>
+<!--<p>+ topic/xref pr-d/synnoteref</p>-->
+</section>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"

--- a/specification/langRef/technicalContent/synph.dita
+++ b/specification/langRef/technicalContent/synph.dita
@@ -21,7 +21,6 @@
         needed, but some of the syntax elements, such as <xmlelement>kwd</xmlelement>,
           <xmlelement>oper</xmlelement>, or <xmlelement>delim</xmlelement> are used within the text
         flow of the topic content.</p>
-      <p>This element is part of the programming domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/syntaxdiagram.dita
+++ b/specification/langRef/technicalContent/syntaxdiagram.dita
@@ -16,10 +16,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>syntaxdiagram</xmlelement> is specialized from

--- a/specification/langRef/technicalContent/var.dita
+++ b/specification/langRef/technicalContent/var.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the programming domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>var</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

I noticed that a bunch of programming domain topics had conref errors in the build, which caused me to notice that the conref was bringing in duplicate information ("This element is part of the programming domain") already specified in another section of the same topic.

This update cleans up all of the programming domain topics so that they use the latest pattern for the Specialization hierarchy section, and removes the duplicate info about the domain group from the "Usage information" section. When that was the only information in the usage information, I've removed that section.

For one topic (`synnote`), the usage information included both information about how to use the element and information about how the element is rendered. I moved that rendering info into the proper section.