### PR TITLE
Update usage info in domains topics

### DIFF
--- a/specification/langRef/technicalContent/cmdname.dita
+++ b/specification/langRef/technicalContent/cmdname.dita
@@ -16,10 +16,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the software domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>cmdname</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/filepath.dita
+++ b/specification/langRef/technicalContent/filepath.dita
@@ -17,10 +17,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the software domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>filepath</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/menucascade.dita
+++ b/specification/langRef/technicalContent/menucascade.dita
@@ -18,11 +18,10 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
+    <!--<section id="usage-information">
       <title>Usage information</title>
-      <!--<p>The <xmlelement>menucascade</xmlelement> element contains one or more user interface control (<xmlelement>uicontrol</xmlelement>) elements, for example: <codeph>Start &gt; Programs &gt; Accessories &gt; Notepad</codeph>. </p>-->
-      <p>This element is part of the user interface domain.</p>
-    </section>
+      <p>The <xmlelement>menucascade</xmlelement> element contains one or more user interface control (<xmlelement>uicontrol</xmlelement>) elements, for example: <codeph>Start &gt; Programs &gt; Accessories &gt; Notepad</codeph>. </p>
+    </section>-->
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>menucascade</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/msgblock.dita
+++ b/specification/langRef/technicalContent/msgblock.dita
@@ -21,7 +21,6 @@
         message descriptions, each enclosed in <xmlelement>msgnum</xmlelement> and
           <xmlelement>msgph</xmlelement> elements. It also can contain the message content
         directly.</p>
-      <p>This element is part of the software domain.</p>
     </section>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>

--- a/specification/langRef/technicalContent/msgnum.dita
+++ b/specification/langRef/technicalContent/msgnum.dita
@@ -14,10 +14,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the software domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>msgnum</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/numcharref.dita
+++ b/specification/langRef/technicalContent/numcharref.dita
@@ -20,7 +20,6 @@
       <p>The content of the <xmlelement>numcharref</xmlelement> element should be the numeric value
         without any leading or trailing characters, for example, <keyword>10</keyword> or<keyword>
           x0a</keyword>.</p>
-      <p>This element is part of the XML mention domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/parameterentity.dita
+++ b/specification/langRef/technicalContent/parameterentity.dita
@@ -21,7 +21,6 @@
         content of the <xmlelement>parameterentity</xmlelement> element should be the entity name
         without a leading percentage sign or trailing semi-colon, for example,
           <keyword>keyword.content</keyword>.</p>
-      <p>This element is part of the XML mention domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/screen.dita
+++ b/specification/langRef/technicalContent/screen.dita
@@ -3,7 +3,7 @@
 <reference id="screen" xml:lang="en-us">
   <title><xmlelement>screen</xmlelement></title>
   <shortdesc>The <xmlelement>screen</xmlelement> element contains a textual representation of a
-    terminal conconsole or other text-based computer interfaces.</shortdesc>
+    terminal console or other text-based computer interfaces.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -15,11 +15,10 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
+    <!--<section id="usage-information">
       <title>Usage information</title>
-      <!--<p>Use <xmlelement>screen</xmlelement> to contain representations of text-based online panels, text consoles ("term" or "curses" windows, for example), or other text-based user interface components.</p>-->
-      <p>This element is part of the user interface domain.</p>
-    </section>
+      <p>Use <xmlelement>screen</xmlelement> to contain representations of text-based online panels, text consoles ("term" or "curses" windows, for example), or other text-based user interface components.</p>
+    </section>-->
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>screen</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/shortcut.dita
+++ b/specification/langRef/technicalContent/shortcut.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the user interface domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>shortcut</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/systemoutput.dita
+++ b/specification/langRef/technicalContent/systemoutput.dita
@@ -15,11 +15,10 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
+    <!--<section id="usage-information">
       <title>Usage information</title>
-      <!--<p>A generalized element, it represents any kind of output from the computer, so the author <ph>might want</ph> to choose more specific markup, such as <xmlelement>msgph</xmlelement> for messages from the application. </p>-->
-      <p>This element is part of the software domain.</p>
-    </section>
+      <p>A generalized element, it represents any kind of output from the computer, so the author <ph>might want</ph> to choose more specific markup, such as <xmlelement>msgph</xmlelement> for messages from the application. </p>
+    </section>-->
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>systemoutput</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/textentity.dita
+++ b/specification/langRef/technicalContent/textentity.dita
@@ -20,7 +20,6 @@
       <p><!--The <xmlelement>textentity</xmlelement> element enables more precise semantic searching of the DITA source; it also enables distinct formatting, such as adding an ampersand (&amp;) as a leading character and a semi-colon (;) as a trailing character. -->The
         content of the <xmlelement>textentity</xmlelement> element should be the entity name without
         the ampersand and semi-colon delimiters, for example, <keyword>hi-d-att</keyword>.</p>
-      <p>This element is part of the XML mention domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/uicontrol.dita
+++ b/specification/langRef/technicalContent/uicontrol.dita
@@ -24,7 +24,6 @@
           <uicontrol>File</uicontrol>
           <uicontrol>New</uicontrol>
         </menucascade>. </p>
-      <p>This element is part of the user interface domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/userinput.dita
+++ b/specification/langRef/technicalContent/userinput.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-<section id="usage-information">
-         <title>Usage information</title>
-         <p>This element is part of the software domain.</p>
-      </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>userinput</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/varname.dita
+++ b/specification/langRef/technicalContent/varname.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the software domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>varname</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/wintitle.dita
+++ b/specification/langRef/technicalContent/wintitle.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the user interface domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>wintitle</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/xmlatt.dita
+++ b/specification/langRef/technicalContent/xmlatt.dita
@@ -19,7 +19,6 @@
       <p>The content of the <xmlelement>xmlatt</xmlelement> element should be the attribute name
         without commercial at symbol (@) or equals character (=) , for example,
           <keyword>audience</keyword>.</p>
-      <p>This element is part of the XML mention domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/xmlelement.dita
+++ b/specification/langRef/technicalContent/xmlelement.dita
@@ -19,7 +19,6 @@
       <p><!--The <xmlelement>xmlelement</xmlelement> element enables more precise semantic searching of the DITA source; it also enables distinct formatting, such as surrounding the name of the element with angle brackets.-->The
         content of the <xmlelement>xmlelement</xmlelement> element should be the element type name
         without leading or trailing angle brackets.</p>
-      <p>This element is part of the XML mention domain.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/xmlnsname.dita
+++ b/specification/langRef/technicalContent/xmlnsname.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the XML mention domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>xmlnsname</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/xmlpi.dita
+++ b/specification/langRef/technicalContent/xmlpi.dita
@@ -15,10 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>This element is part of the XML mention domain.</p>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>xmlpi</xmlelement> element is specialized from


### PR DESCRIPTION
Prompted by #45, makes the same update to remove duplicate "This is in the X domain" statement from usage info in software, UI, and XML Mention domains. The same info is already available elsewhere in each topic.