### PR TITLE
Make outputclass universal

### DIFF
--- a/specification/langRef/technicalContent/booktitle.dita
+++ b/specification/langRef/technicalContent/booktitle.dita
@@ -21,7 +21,6 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"
-        /> (without the Metadata attribute group) and <xref keyref="commonAttributes/outputclass"
         />.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/change-historylist.dita
+++ b/specification/langRef/technicalContent/change-historylist.dita
@@ -27,7 +27,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"
-        />, <xref keyref="commonAttributes/outputclass"/>, and <xref
+        /> and <xref
           keyref="commonAttributes/mapkeyref"/>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/choicetable.dita
+++ b/specification/langRef/technicalContent/choicetable.dita
@@ -30,8 +30,7 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"
         />, <xref keyref="displayAttributes"/>, <xref keyref="simpletableAttributes"/> (with a
-        narrowed definition of <xmlatt>keycol</xmlatt>, given below), <xref
-          keyref="commonAttributes/outputclass"/>, and <xref
+        narrowed definition of <xmlatt>keycol</xmlatt>, given below), and <xref
           keyref="specializationAttributes/spectitle"/>.<dl>
           <dlentry>
             <dt><xmlatt>keycol</xmlatt></dt>

--- a/specification/langRef/technicalContent/fragref.dita
+++ b/specification/langRef/technicalContent/fragref.dita
@@ -25,8 +25,7 @@ defined in the programming domain module.</p>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"
-        /> (with a narrowed definition of <xmlatt>importance</xmlatt>, given below), <xref
-          keyref="commonAttributes/outputclass"/>, and the attributes defined below.</p>
+        /> (with a narrowed definition of <xmlatt>importance</xmlatt>, given below) and the attributes defined below.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>href</xmlatt></dt>

--- a/specification/langRef/technicalContent/glossAlternateFor.dita
+++ b/specification/langRef/technicalContent/glossAlternateFor.dita
@@ -29,10 +29,9 @@
       <p>The following attributes are available on this element: <xref
           keyref="universalAttributes"/>, <xref
           keyref="linkRelationshipAttributes"/> (with a narrowed definition of
-          <xmlatt>href</xmlatt>, given below), <xref
+          <xmlatt>href</xmlatt>, given below), and <xref
             keyref="thekeyrefattribute"
-          ><xmlatt>keyref</xmlatt></xref>, and <xref
-          keyref="commonAttributes/outputclass"/>.<dl>
+          ><xmlatt>keyref</xmlatt></xref>.<dl>
           <dlentry>
             <dt><xmlatt>href</xmlatt></dt>
             <dd>References a term for which the current variant is an alternate (in addition to the

--- a/specification/langRef/technicalContent/glossPartOfSpeech.dita
+++ b/specification/langRef/technicalContent/glossPartOfSpeech.dita
@@ -32,8 +32,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="dataElementAttributes"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
-        given below), <xref keyref="linkRelationshipAttributes"/>, <xref
-          keyref="universalAttributes"/>, and <xref keyref="commonAttributes/outputclass"/>.</p>
+        given below), <xref keyref="linkRelationshipAttributes"/>, and <xref
+          keyref="universalAttributes"/>.</p>
       <dl>
         <dlentry>
           <dt id="value"><xmlatt>value</xmlatt></dt>

--- a/specification/langRef/technicalContent/glossStatus.dita
+++ b/specification/langRef/technicalContent/glossStatus.dita
@@ -32,8 +32,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
           keyref="dataElementAttributes"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
-        given below), <xref keyref="linkRelationshipAttributes"/>, <xref
-          keyref="universalAttributes"/>, and <xref keyref="commonAttributes/outputclass"/>.</p>
+        given below), <xref keyref="linkRelationshipAttributes"/>, and <xref
+          keyref="universalAttributes"/>.</p>
       <dl>
         <dlentry>
           <dt id="value"><xmlatt>value</xmlatt></dt>

--- a/specification/langRef/technicalContent/glossSymbol.dita
+++ b/specification/langRef/technicalContent/glossSymbol.dita
@@ -21,7 +21,6 @@
       <!--RDA: Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of hazardsymbol.-->
       <p>The following attributes are available on this element: <xref
           keyref="universalAttributes"/>, <xref
-          keyref="commonAttributes/outputclass"/>, <xref
           keyref="thekeyrefattribute"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/technicalContent/glossref.dita
+++ b/specification/langRef/technicalContent/glossref.dita
@@ -32,7 +32,6 @@ and expanded versions of that acronym.</shortdesc>
             keyref="topicrefElementAttributes"/>, <xref
           keyref="linkRelationshipAttributes"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
-          keyref="commonAttributes/outputclass"/>, <xref
           keyref="thekeyrefattribute"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below. This element also uses <xmlatt>processing-role</xmlatt>,
           <xmlatt>collection-type</xmlatt>, <xmlatt>locktitle</xmlatt>, <xmlatt>chunk</xmlatt>, and

--- a/specification/langRef/technicalContent/step.dita
+++ b/specification/langRef/technicalContent/step.dita
@@ -18,8 +18,7 @@
 </section>
 <section id="attributes"><title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> (with a narrowed definition of <xmlatt>importance</xmlatt>, given below) and <xref
-          keyref="attributes-universal/outputclass"/>.</p>
+        /> (with a narrowed definition of <xmlatt>importance</xmlatt>, given below).</p>
       <dl>
         <dlentry>
           <dt>importance</dt>

--- a/specification/langRef/technicalContent/synnoteref.dita
+++ b/specification/langRef/technicalContent/synnoteref.dita
@@ -29,7 +29,7 @@ defined in the programming domain module.</p>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="universalAttributes"
-        />, <xref keyref="commonAttributes/outputclass"/>, and the attribute defined below.</p>
+        /> and the attribute defined below.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>href</xmlatt></dt>


### PR DESCRIPTION
Update specification files (the "Attributes" section of language reference topics) to reflect changes from https://github.com/robander/dita-techcomm/pull/new/universalOutputclass

The grammar files were already updated as part of the initial work to make them valid against the DITA 2.0 base grammar files.