### PR TITLE
Fix path in classify map catalog

### DIFF
--- a/doctypes/dtd/classificationMap/catalog.xml
+++ b/doctypes/dtd/classificationMap/catalog.xml
@@ -4,5 +4,5 @@
    <public publicId="-//OASIS//DTD DITA 2.0 Classification Map//EN"
            uri="classifyMap.dtd"/>
    <public publicId="-//OASIS//DTD DITA 2.x Classification Map//EN"
-           uri="dtd/classifyMap.dtd"/>
+           uri="classifyMap.dtd"/>
 </catalog>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes a typo in the catalog for 2.x Classification map.