### PR TITLE
Fix typo in classify map RNG catalog

### DIFF
--- a/doctypes/rng/classificationMap/catalog.xml
+++ b/doctypes/rng/classificationMap/catalog.xml
@@ -5,12 +5,12 @@
       <system systemId="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:2.0"
               uri="classifyMap.rng"/>
       <system systemId="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:2.x"
-              uri="rng/classifyMap.rng"/>
+              uri="classifyMap.rng"/>
    </group>
    <group><!-- Public ID (URN) catalog entries -->
       <uri name="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:2.0"
            uri="classifyMap.rng"/>
       <uri name="urn:oasis:names:tc:dita:spec:classification:rng:classifyMap.rng:2.x"
-           uri="rng/classifyMap.rng"/>
+           uri="classifyMap.rng"/>
    </group>
 </catalog>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fix typo in the RNG catalog with the same patch that was applied to DTD catalog with #50 