### PR TITLE
Update Travis test to include 2.x public IDs

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -8,5 +8,5 @@ export DITA_HOME=$PWD/dita-ot-$DITA_OT_VERSION
 #$DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita1.3/dtd/base/basemap.ditamap -f html5
 
 # Build beta 2.0 doctype
-$DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/dita20/2.0grammars-techcomm.ditamap -f html5 --processing-mode=strict -v
+$DITA_HOME/bin/dita -i $PWD/metadita-sampledocs-master/doctypes/all-v2-grammars-techcomm.ditamap -f html5 --processing-mode=strict -v
 $DITA_HOME/bin/dita -i $PWD/specification/dita-2.0-technical-content-specification.ditamap -f html5 --processing-mode=strict -v


### PR DESCRIPTION
Switches the test map used to verify each grammar file works (parses correctly and is in the catalog).

Earlier version pulled in a sample set that uses a document with each DITA 2.0 public ID, and verified that each grammar file was found and was parsed. I've updated the sample set with https://github.com/robander/metadita-sampledocs/commit/59f38ef4bd42f90fa820180396495b4cfb4b7630 to include a 2.x version of each 2.0 doctype.

This pull request updates our Travis test so that it runs both the 2.0 and 2.x files at one time. It also updates the submodule pointer to the latest DITA repo, so that we pick up the 2.x declarations from those catalogs as well.