### PR TITLE
Add keys for base reuse topics

### DIFF
--- a/specification/dita-2.0-technical-content-specification.ditamap
+++ b/specification/dita-2.0-technical-content-specification.ditamap
@@ -31,6 +31,7 @@
     </bookrights>
   </bookmeta>
   <frontmatter>
+    <mapref href="baseSpec/specification/common/key-definitions-library-topics.ditamap"/>
     <mapref href="stubs/KeyStubs.ditamap" processing-role="resource-only"/>
     <!--    <mapref href="dita-20-key-definitions-common-metadata.ditamap" processing-role="resource-only"/>
     <mapref href="dita-20-key-definitions-part2-metadata.ditamap" processing-role="resource-only"/>-->


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This allows key references to common reused files to work properly.