### PR TITLE
Fix broken attlist for change-historylist

### DIFF
--- a/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/releaseManagementDomain.mod
@@ -56,7 +56,10 @@
                        "(%change-item;)*"
 >
 <!ENTITY % change-historylist.attributes
-              "%changehistory.data.atts;"
+              "%univ-atts;
+               mapkeyref
+                          CDATA
+                                    #IMPLIED"
 >
 <!ELEMENT  change-historylist %change-historylist.content;>
 <!ATTLIST  change-historylist %change-historylist.attributes;>

--- a/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
+++ b/doctypes/rng/technicalContent/rng/releaseManagementDomain.rng
@@ -106,7 +106,10 @@ PUBLIC "-//OASIS//ENTITIES DITA 2.0 Release Management Domain//EN"
         </zeroOrMore>
       </define>
       <define name="change-historylist.attributes">
-        <ref name="changehistory.data.atts"/>
+        <ref name="univ-atts"/>
+        <optional>
+          <attribute name="mapkeyref"/>
+        </optional>
       </define>
       <define name="change-historylist.element">
         <element name="change-historylist" dita:longName="Change History List"


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Cleans up attribute list for `change-historylist`, which was technically incorrect in the 1.3 grammar files (but correct in the written spec), as discussed at TC December 10, 2019.