### PR TITLE
Update specializations of "include" to nest fallback

### DIFF
--- a/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/mathmlDomain.mod
@@ -31,7 +31,7 @@
 
 <!--                    LONG NAME: MathML reference                -->
 <!ENTITY % mathmlref.content
-                       "EMPTY"
+                       "(%fallback;)?"
 >
 <!ENTITY % mathmlref.attributes
               "href

--- a/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/programmingDomain.mod
@@ -125,7 +125,7 @@
 
 <!--                    LONG NAME: Literal code reference          -->
 <!ENTITY % coderef.content
-                       "EMPTY"
+                       "(%fallback;)?"
 >
 <!ENTITY % coderef.attributes
               "href

--- a/doctypes/dtd/technicalContent/dtd/svgDomain.mod
+++ b/doctypes/dtd/technicalContent/dtd/svgDomain.mod
@@ -38,7 +38,7 @@
 
 <!--                    LONG NAME: SVG element reference           -->
 <!ENTITY % svgref.content
-                       "EMPTY"
+                       "(%fallback;)?"
 >
 <!ENTITY % svgref.attributes
               "href

--- a/doctypes/rng/technicalContent/rng/mathmlDomain.rng
+++ b/doctypes/rng/technicalContent/rng/mathmlDomain.rng
@@ -73,7 +73,9 @@ All Rights Reserved.
     <div>
       <a:documentation>FULL NAME: MathML reference</a:documentation>
       <define name="mathmlref.content">
-        <empty/>
+        <optional>
+          <ref name="fallback"/>
+        </optional>
       </define>
       <define name="mathmlref.attributes">
         <optional>

--- a/doctypes/rng/technicalContent/rng/programmingDomain.rng
+++ b/doctypes/rng/technicalContent/rng/programmingDomain.rng
@@ -266,7 +266,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Programming Domain//EN"
     <div>
       <a:documentation> LONG NAME: Literal code reference </a:documentation>
       <define name="coderef.content">
-        <empty/>
+        <optional>
+          <ref name="fallback"/>
+        </optional>
       </define>
       <define name="coderef.attributes">
         <optional>

--- a/doctypes/rng/technicalContent/rng/svgDomain.rng
+++ b/doctypes/rng/technicalContent/rng/svgDomain.rng
@@ -85,7 +85,9 @@ DITA SVG Domain
     <div>
       <a:documentation>LONG NAME: SVG referece</a:documentation>
       <define name="svgref.content">
-        <empty/>
+        <optional>
+          <ref name="fallback"/>
+        </optional>
       </define>
       <define name="svgref.attributes">
         <optional>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Action item from December 10, update `svgref`, `mathmlref`, and `coderef` to nest the new `fallback` element.

https://lists.oasis-open.org/archives/dita/201912/msg00048.html