### PR TITLE
Fix troubleSolution specialization base

### DIFF
--- a/specification/langRef/technicalContent/troubleSolution.dita
+++ b/specification/langRef/technicalContent/troubleSolution.dita
@@ -23,7 +23,7 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/section troubleshooting/troubleSolution</p>
+      <p>- topic/bodydiv troubleshooting/troubleSolution</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>


### PR DESCRIPTION
Signed-off-by: Robert D. Anderson <robert.dan.anderson@oracle.com>

`troubleSolution` is specialized from `bodydiv`, but the DITA 1.3 spec listed its base as `section`