### PR TITLE
Reformat specialization hierarchy section for TC domains

### DIFF
--- a/specification/langRef/technicalContent/addressdetails.dita
+++ b/specification/langRef/technicalContent/addressdetails.dita
@@ -17,9 +17,7 @@
     <section id="specialization-hierarchy"
         ><title>Specialization hierarchy</title>
       <p>The <xmlelement>addressdetails</xmlelement> is specialized from
-        <xmlelement>ph</xmlelement>. It is defined in the XNAL domain.</p>
-      <p>The value of the <xmlatt>class</xmlatt> attribute is <keyword>+ topic/ph
-          xnal-d/addressdetails </keyword>.</p></section>
+        <xmlelement>ph</xmlelement>. It is defined in the XNAL domain.</p></section>
     <section id="attributes"><title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>

--- a/specification/langRef/technicalContent/administrativearea.dita
+++ b/specification/langRef/technicalContent/administrativearea.dita
@@ -18,7 +18,7 @@
       <section id="specialization-hierarchy"
             ><title>Specialization hierarchy</title>
          <p>The <xmlelement>administrativearea</xmlelement> element is specialized from
-               <xmlelement>topic</xmlelement>. It is defined in the XNAL domain module.</p></section>
+               <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p></section>
       <section id="attributes"><title>Attributes</title>
          <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </section>

--- a/specification/langRef/technicalContent/apiname.dita
+++ b/specification/langRef/technicalContent/apiname.dita
@@ -20,8 +20,7 @@
       <section id="specialization-hierarchy"
             ><title>Specialization hierarchy</title>
          <p>The <xmlelement>apiname</xmlelement> is specialized from
-               <xmlelement>keyword</xmlelement>. It is defined in the programming domain module.</p>
-         <!--<p>+ topic/keyword pr-d/apiname</p>--></section>
+               <xmlelement>keyword</xmlelement>. It is defined in the programming domain module.</p></section>
       <section id="attributes"><title>Attributes</title>
          <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </section>

--- a/specification/langRef/technicalContent/change-completed.dita
+++ b/specification/langRef/technicalContent/change-completed.dita
@@ -20,7 +20,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-completed</p>
+      <p>The <xmlelement>change-completed</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-historylist.dita
+++ b/specification/langRef/technicalContent/change-historylist.dita
@@ -22,7 +22,9 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/metadata relmgmt-d/change-historylist</p>
+      <p>The <xmlelement>change-historylist</xmlelement> is specialized from
+          <xmlelement>metadata</xmlelement>. It is defined in the release management domain
+        module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-item.dita
+++ b/specification/langRef/technicalContent/change-item.dita
@@ -18,7 +18,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>change-item</xmlelement> is specialized from <xmlelement>data</xmlelement>.
         It is defined in the release management domain module.</p>
-      <p>- topic/data relmgmt-d/change-item</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-item.dita
+++ b/specification/langRef/technicalContent/change-item.dita
@@ -16,6 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
+      <p>The <xmlelement>change-item</xmlelement> is specialized from <xmlelement>data</xmlelement>.
+        It is defined in the release management domain module.</p>
       <p>- topic/data relmgmt-d/change-item</p>
     </section>
     <section id="attributes">

--- a/specification/langRef/technicalContent/change-organization.dita
+++ b/specification/langRef/technicalContent/change-organization.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-organization</p>
+      <p>The <xmlelement>change-organization</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-person.dita
+++ b/specification/langRef/technicalContent/change-person.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-person</p>
+      <p>The <xmlelement>change-person</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-request-id.dita
+++ b/specification/langRef/technicalContent/change-request-id.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-request-id</p>
+      <p>The <xmlelement>change-request-id</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-request-reference.dita
+++ b/specification/langRef/technicalContent/change-request-reference.dita
@@ -16,7 +16,9 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/metadata relmgmt-d/change-request-reference</p>
+      <p>The <xmlelement>change-request-reference</xmlelement> is specialized from
+          <xmlelement>metadata</xmlelement>. It is defined in the release management domain
+        module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-request-system.dita
+++ b/specification/langRef/technicalContent/change-request-system.dita
@@ -17,7 +17,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-request-system</p>
+      <p>The <xmlelement>change-request-system</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-revisionid.dita
+++ b/specification/langRef/technicalContent/change-revisionid.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-revisionid</p>
+      <p>The <xmlelement>change-revisionid</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-started.dita
+++ b/specification/langRef/technicalContent/change-started.dita
@@ -20,7 +20,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-started</p>
+      <p>The <xmlelement>change-started</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/change-summary.dita
+++ b/specification/langRef/technicalContent/change-summary.dita
@@ -20,7 +20,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>- topic/data relmgmt-d/change-summary</p>
+      <p>The <xmlelement>change-summary</xmlelement> is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the release management domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/cmdname.dita
+++ b/specification/langRef/technicalContent/cmdname.dita
@@ -20,7 +20,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>cmdname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>. It is defined in the software domain module.</p>
-      <!--<p>+ topic/keyword sw-d/cmdname</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -24,7 +24,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>codeblock</xmlelement> is specialized from <xmlelement>pre</xmlelement>. It
         is defined in the programming domain module.</p>
-      <!--<p>+ topic/pre pr-d/codeblock</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/codeph.dita
+++ b/specification/langRef/technicalContent/codeph.dita
@@ -18,7 +18,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>codeph</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/ph pr-d/codeph</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -28,7 +28,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>coderef</xmlelement> is specialized from <xmlelement>include</xmlelement>. It
         is defined in the programming domain module.</p>
-      <!--<p>+ topic/include pr-d/coderef</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/contactnumber.dita
+++ b/specification/langRef/technicalContent/contactnumber.dita
@@ -17,7 +17,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/contactnumber</p>
+      <p>The <xmlelement>contactnumber</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/contactnumbers.dita
+++ b/specification/langRef/technicalContent/contactnumbers.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/contactnumbers</p>
+      <p>The <xmlelement>contactnumbers</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/country.dita
+++ b/specification/langRef/technicalContent/country.dita
@@ -15,7 +15,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph xnal-d/country</p>
+      <p>The <xmlelement>country</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/delim.dita
+++ b/specification/langRef/technicalContent/delim.dita
@@ -24,7 +24,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>delim</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/ph pr-d/delim</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/emailaddress.dita
+++ b/specification/langRef/technicalContent/emailaddress.dita
@@ -15,7 +15,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/emailaddress</p>
+      <p>The <xmlelement>emailaddress</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/emailaddresses.dita
+++ b/specification/langRef/technicalContent/emailaddresses.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/emailaddresses</p>
+      <p>The <xmlelement>emailaddresses</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-block.dita
+++ b/specification/langRef/technicalContent/equation-block.dita
@@ -33,7 +33,7 @@
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>equation-block</xmlelement> element is specialized from
-          <xmlelement>div</xmlelement>. It is defined in the equation-domain module.</p>
+          <xmlelement>div</xmlelement>. It is defined in the equation domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-block.dita
+++ b/specification/langRef/technicalContent/equation-block.dita
@@ -32,7 +32,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/divequation-d/equation-block</p>
+      <p>The <xmlelement>equation-block</xmlelement> element is specialized from
+          <xmlelement>div</xmlelement>. It is defined in the equation-domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-figure.dita
+++ b/specification/langRef/technicalContent/equation-figure.dita
@@ -46,7 +46,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/fig equation-d/equation-figure</p>
+      <p>The <xmlelement>equation-figure</xmlelement> element is specialized from
+          <xmlelement>fig</xmlelement>. It is defined in the equation-domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-figure.dita
+++ b/specification/langRef/technicalContent/equation-figure.dita
@@ -47,7 +47,7 @@
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>equation-figure</xmlelement> element is specialized from
-          <xmlelement>fig</xmlelement>. It is defined in the equation-domain module.</p>
+          <xmlelement>fig</xmlelement>. It is defined in the equation domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-inline.dita
+++ b/specification/langRef/technicalContent/equation-inline.dita
@@ -29,7 +29,8 @@
       </section>    
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph equation-d/equation-inline</p>
+      <p>The <xmlelement>equation-inline</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the equation-domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-inline.dita
+++ b/specification/langRef/technicalContent/equation-inline.dita
@@ -30,7 +30,7 @@
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>equation-inline</xmlelement> element is specialized from
-          <xmlelement>ph</xmlelement>. It is defined in the equation-domain module.</p>
+          <xmlelement>ph</xmlelement>. It is defined in the equation domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-number.dita
+++ b/specification/langRef/technicalContent/equation-number.dita
@@ -37,7 +37,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph equation-d/equation-number</p>
+      <p>The <xmlelement>equation-number</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the equation-domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/equation-number.dita
+++ b/specification/langRef/technicalContent/equation-number.dita
@@ -38,7 +38,7 @@
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>equation-number</xmlelement> element is specialized from
-          <xmlelement>ph</xmlelement>. It is defined in the equation-domain module.</p>
+          <xmlelement>ph</xmlelement>. It is defined in the equation domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/filepath.dita
+++ b/specification/langRef/technicalContent/filepath.dita
@@ -21,7 +21,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>filepath</xmlelement> element is specialized from
           <xmlelement>ph</xmlelement>. It is defined in the software domain module.</p>
-      <!--<p>+ topic/ph sw-d/filepath</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/firstname.dita
+++ b/specification/langRef/technicalContent/firstname.dita
@@ -15,7 +15,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/firstname</p>
+      <p>The <xmlelement>firstname</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/fragment.dita
+++ b/specification/langRef/technicalContent/fragment.dita
@@ -24,7 +24,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>fragment</xmlelement> element is specialized from
           <xmlelement>figgroup</xmlelement>. It is defined in the programming domain module.</p>
-      <!--<p>+ topic/figgroup pr-d/fragment</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/fragref.dita
+++ b/specification/langRef/technicalContent/fragref.dita
@@ -20,7 +20,6 @@
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>fragref</xmlelement> is specialized from <xmlelement>xref</xmlelement>. It is
 defined in the programming domain module.</p>
-<!--<p>+ topic/xref pr-d/fragref</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/generationidentifier.dita
+++ b/specification/langRef/technicalContent/generationidentifier.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/generationidentifier</p>
+      <p>The <xmlelement>generationidentifier</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/groupchoice.dita
+++ b/specification/langRef/technicalContent/groupchoice.dita
@@ -24,7 +24,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>groupchoice</xmlelement> element is specialized from
           <xmlelement>figgroup</xmlelement>. It is defined in the programming domain module.</p>
-      <!--<p>+ topic/figgroup pr-d/groupchoice</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/groupcomp.dita
+++ b/specification/langRef/technicalContent/groupcomp.dita
@@ -27,7 +27,6 @@ separated by a horizontal or vertical line, which is the usual formatting method
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>groupcomp</xmlelement> is specialized from <xmlelement>figgroup</xmlelement>. It
 is defined in the programming domain module.</p>
-<!--<p>+ topic/figgroup pr-d/groupcomp</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/groupseq.dita
+++ b/specification/langRef/technicalContent/groupseq.dita
@@ -26,7 +26,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>groupseq</xmlelement> element is specialized from
           <xmlelement>figgroup</xmlelement>. It is defined in the programming domain module.</p>
-      <!--<p>+ topic/figgroup pr-d/groupseq</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/honorific.dita
+++ b/specification/langRef/technicalContent/honorific.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/honorific</p>
+      <p>The <xmlelement>honorific</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/kwd.dita
+++ b/specification/langRef/technicalContent/kwd.dita
@@ -23,7 +23,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>kwd</xmlelement> is specialized from <xmlelement>keyword</xmlelement>. It
         is defined in the programming domain module.</p>
-      <!--<p>+ topic/keyword pr-d/kwd</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/lastname.dita
+++ b/specification/langRef/technicalContent/lastname.dita
@@ -15,7 +15,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/lastname</p>
+      <p>The <xmlelement>lastname</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/locality.dita
+++ b/specification/langRef/technicalContent/locality.dita
@@ -21,7 +21,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph xnal-d/locality</p>
+      <p>The <xmlelement>locality</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/localityname.dita
+++ b/specification/langRef/technicalContent/localityname.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph xnal-d/localityname</p>
+      <p>The <xmlelement>localityname</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/mathml.dita
+++ b/specification/langRef/technicalContent/mathml.dita
@@ -26,7 +26,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/foreign mathml-d/mathml</p>
+      <p>The <xmlelement>mathml</xmlelement> element is specialized from
+          <xmlelement>foreign</xmlelement>. It is defined in the mathml-domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/mathml.dita
+++ b/specification/langRef/technicalContent/mathml.dita
@@ -27,7 +27,7 @@
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>mathml</xmlelement> element is specialized from
-          <xmlelement>foreign</xmlelement>. It is defined in the mathml-domain module.</p>
+          <xmlelement>foreign</xmlelement>. It is defined in the MathML domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -49,7 +49,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/include mathml-d/mathmlref</p>
+      <p>The <xmlelement>mathmlref</xmlelement> element is specialized from
+          <xmlelement>include</xmlelement>. It is defined in the mathml-domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -50,7 +50,7 @@
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>mathmlref</xmlelement> element is specialized from
-          <xmlelement>include</xmlelement>. It is defined in the mathml-domain module.</p>
+          <xmlelement>include</xmlelement>. It is defined in the MathML domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/menucascade.dita
+++ b/specification/langRef/technicalContent/menucascade.dita
@@ -26,7 +26,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>menucascade</xmlelement> element is specialized from
           <xmlelement>ph</xmlelement>. It is defined in the user-interface domain module.</p>
-      <!--<p>+ topic/ph ui-d/menucascade</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/middlename.dita
+++ b/specification/langRef/technicalContent/middlename.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/middlename</p>
+      <p>The <xmlelement>middlename</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/msgblock.dita
+++ b/specification/langRef/technicalContent/msgblock.dita
@@ -31,7 +31,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>msgblock</xmlelement> element is specialized from
           <xmlelement>pre</xmlelement>. It is defined in the software domain module.</p>
-      <!--<p>+ topic/pre sw-d/msgblock</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/msgnum.dita
+++ b/specification/langRef/technicalContent/msgnum.dita
@@ -18,7 +18,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>msgnum</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>. It is defined in the software domain module.</p>
-      <!--<p>+ topic/keyword sw-d/msgnum</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/msgph.dita
+++ b/specification/langRef/technicalContent/msgph.dita
@@ -23,7 +23,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>msgph</xmlelement> element is specialized from <xmlelement>ph</xmlelement>.
         It is defined in the software domain module.</p>
-      <!--<p>+ topic/ph sw-d/msgph</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/namedetails.dita
+++ b/specification/langRef/technicalContent/namedetails.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/namedetails</p>
+      <p>The <xmlelement>namedetails</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/numcharref.dita
+++ b/specification/langRef/technicalContent/numcharref.dita
@@ -27,7 +27,6 @@
           <xmlelement>markupname</xmlelement>; it is defined in the XML-mention domain module. The
           <xmlelement>markupname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>; it is defined in the markup-name domain module.</p>
-      <!--<p>+ topic/keyword markup-d/markupname xml-d/numcharref</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/oper.dita
+++ b/specification/langRef/technicalContent/oper.dita
@@ -23,7 +23,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>oper</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/ph pr-d/oper</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/option.dita
+++ b/specification/langRef/technicalContent/option.dita
@@ -22,7 +22,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>option</xmlelement> is specialized from <xmlelement>keyword</xmlelement>.
         It is defined in the programming domain module.</p>
-      <!--<p>+ topic/keyword pr-d/option</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/organizationinfo.dita
+++ b/specification/langRef/technicalContent/organizationinfo.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/organizationinfo</p>
+      <p>The <xmlelement>organizationinfo</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/organizationname.dita
+++ b/specification/langRef/technicalContent/organizationname.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph xnal-d/organizationname</p>
+      <p>The <xmlelement>organizationname</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/organizationnamedetails.dita
+++ b/specification/langRef/technicalContent/organizationnamedetails.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph xnal-d/organizationnamedetails</p>
+      <p>The <xmlelement>organizationnamedetails</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/otherinfo.dita
+++ b/specification/langRef/technicalContent/otherinfo.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/otherinfo</p>
+      <p>The <xmlelement>otherinfo</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/parameterentity.dita
+++ b/specification/langRef/technicalContent/parameterentity.dita
@@ -28,7 +28,6 @@
           <xmlelement>markupname</xmlelement>; it is defined in the XML-mention domain module. The
           <xmlelement>markupname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>; it is defined in the markup-name domain module.</p>
-      <!--<p>+ topic/keyword markup-d/markupname xml-d/parameterentity</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/parml.dita
+++ b/specification/langRef/technicalContent/parml.dita
@@ -22,7 +22,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>parml</xmlelement> is specialized from <xmlelement>dl</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/dl pr-d/parml</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/parmname.dita
+++ b/specification/langRef/technicalContent/parmname.dita
@@ -21,7 +21,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>parmname</xmlelement> is specialized from <xmlelement>keyword</xmlelement>.
         It is defined in the programming domain module.</p>
-      <!--<p>+ topic/keyword pr-d/parmname</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/pd.dita
+++ b/specification/langRef/technicalContent/pd.dita
@@ -20,7 +20,6 @@
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>pd</xmlelement> is specialized from <xmlelement>dd</xmlelement>. It is defined in
 the programming domain module.</p>
-<!--<p>+ topic/dd pr-d/pd</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/personinfo.dita
+++ b/specification/langRef/technicalContent/personinfo.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/personinfo</p>
+      <p>The <xmlelement>personinfo</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/personname.dita
+++ b/specification/langRef/technicalContent/personname.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/personname</p>
+      <p>The <xmlelement>personname</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/plentry.dita
+++ b/specification/langRef/technicalContent/plentry.dita
@@ -21,7 +21,6 @@
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>plentry</xmlelement> is specialized from <xmlelement>dlentry</xmlelement>. It is
 defined in the programming domain module.</p>
-<!--<p>+ topic/dlentry pr-d/plentry</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/postalcode.dita
+++ b/specification/langRef/technicalContent/postalcode.dita
@@ -17,7 +17,7 @@
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>postalcode</xmlelement> element is specialized from
-          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/postalcode.dita
+++ b/specification/langRef/technicalContent/postalcode.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph xnal-d/postalcode</p>
+      <p>The <xmlelement>postalcode</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/pt.dita
+++ b/specification/langRef/technicalContent/pt.dita
@@ -20,7 +20,6 @@ list entry.</shortdesc>
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>pt</xmlelement> is specialized from <xmlelement>dt</xmlelement>. It is defined in
 the programming domain module.</p>
-<!--<p>+ topic/dt pr-d/pt</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/repsep.dita
+++ b/specification/langRef/technicalContent/repsep.dita
@@ -24,7 +24,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>repsep</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/ph pr-d/repsep</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/screen.dita
+++ b/specification/langRef/technicalContent/screen.dita
@@ -23,7 +23,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>screen</xmlelement> element is specialized from
           <xmlelement>pre</xmlelement>. It is defined in the user-interface domain module.</p>
-      <!--<p>+ topic/pre ui-d/screen</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/sep.dita
+++ b/specification/langRef/technicalContent/sep.dita
@@ -23,7 +23,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>sep</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/ph pr-d/sep</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/shortcut.dita
+++ b/specification/langRef/technicalContent/shortcut.dita
@@ -19,7 +19,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>shortcut</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>. It is defined in the user-interface domain module.</p>
-      <!--<p>+ topic/keyword ui-d/shortcut</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/svg-container.dita
+++ b/specification/langRef/technicalContent/svg-container.dita
@@ -23,7 +23,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/foreign svg-d/svg-container</p>
+      <p>The <xmlelement>svg-container</xmlelement> is specialized from
+          <xmlelement>foreign</xmlelement>. It is defined in the SVG domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -45,7 +45,8 @@
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/include svg-d/svgref</p>
+      <p>The <xmlelement>svgref</xmlelement> is specialized from <xmlelement>include</xmlelement>.
+        It is defined in the SVG domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/synblk.dita
+++ b/specification/langRef/technicalContent/synblk.dita
@@ -19,7 +19,6 @@
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>synblk</xmlelement> is specialized from <xmlelement>figgroup</xmlelement>. It is
 defined in the programming domain module.</p>
-<!--<p>+ topic/figgroup pr-d/synblk</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/synnote.dita
+++ b/specification/langRef/technicalContent/synnote.dita
@@ -31,7 +31,6 @@ page.</p>
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>synnote</xmlelement> is specialized from <xmlelement>fn</xmlelement>. It is
 defined in the programming domain module.</p>
-<!--<p>+ topic/fn pr-d/synnote</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/synnoteref.dita
+++ b/specification/langRef/technicalContent/synnoteref.dita
@@ -24,7 +24,6 @@
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>synnoteref</xmlelement> is specialized from <xmlelement>xref</xmlelement>. It is
 defined in the programming domain module.</p>
-<!--<p>+ topic/xref pr-d/synnoteref</p>-->
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/synph.dita
+++ b/specification/langRef/technicalContent/synph.dita
@@ -26,7 +26,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>synph</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/ph pr-d/synph</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/syntaxdiagram.dita
+++ b/specification/langRef/technicalContent/syntaxdiagram.dita
@@ -20,7 +20,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>syntaxdiagram</xmlelement> is specialized from
         <xmlelement>fig</xmlelement>. It is defined in the programming domain module.</p>
-      <!--<p>+ topic/fig pr-d/syntaxdiagram</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/systemoutput.dita
+++ b/specification/langRef/technicalContent/systemoutput.dita
@@ -23,7 +23,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>systemoutput</xmlelement> element is specialized from
           <xmlelement>ph</xmlelement>. It is defined in the software domain module.</p>
-      <!--<p>+ topic/ph sw-d/systemoutput</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/textentity.dita
+++ b/specification/langRef/technicalContent/textentity.dita
@@ -27,7 +27,6 @@
           <xmlelement>markupname</xmlelement>; it is defined in the XML-mention domain module. The
           <xmlelement>markupname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>; it is defined in the markup-name domain module.</p>
-      <!--<p>+ topic/keyword markup-d/markupname xml-d/textentity</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/thoroughfare.dita
+++ b/specification/langRef/technicalContent/thoroughfare.dita
@@ -17,7 +17,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/ph xnal-d/thoroughfare</p>
+      <p>The <xmlelement>thoroughfare</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/uicontrol.dita
+++ b/specification/langRef/technicalContent/uicontrol.dita
@@ -29,7 +29,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>uicontrol</xmlelement> element is specialized from
           <xmlelement>ph</xmlelement>. It is defined in the user-interface domain module.</p>
-      <!--<p>+ topic/ph ui-d/uicontrol</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/url.dita
+++ b/specification/langRef/technicalContent/url.dita
@@ -16,7 +16,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/url</p>
+      <p>The <xmlelement>url</xmlelement> element is specialized from <xmlelement>data</xmlelement>.
+        It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/urls.dita
+++ b/specification/langRef/technicalContent/urls.dita
@@ -15,7 +15,8 @@
   <refbody>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
-      <p>+ topic/data xnal-d/urls</p>
+      <p>The <xmlelement>urls</xmlelement> element is specialized from
+        <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/userinput.dita
+++ b/specification/langRef/technicalContent/userinput.dita
@@ -19,7 +19,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>userinput</xmlelement> element is specialized from
           <xmlelement>ph</xmlelement>. It is defined in the software domain module.</p>
-      <!--<p>+ topic/ph sw-d/userinput</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/var.dita
+++ b/specification/langRef/technicalContent/var.dita
@@ -19,7 +19,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>var</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is
         defined in the programming domain module.</p>
-      <!--<p>+ topic/ph pr-d/var</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/varname.dita
+++ b/specification/langRef/technicalContent/varname.dita
@@ -19,7 +19,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>varname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>. It is defined in the software domain module.</p>
-      <!--<p>+ topic/keyword sw-d/varname</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/wintitle.dita
+++ b/specification/langRef/technicalContent/wintitle.dita
@@ -19,7 +19,6 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>wintitle</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>. It is defined in the user-interface domain module.</p>
-      <!--<p>+ topic/keyword ui-d/wintitle</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/xmlatt.dita
+++ b/specification/langRef/technicalContent/xmlatt.dita
@@ -26,7 +26,6 @@
           <xmlelement>markupname</xmlelement>; it is defined in the XML-mention domain module. The
           <xmlelement>markupname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>; it is defined in the markup-name domain module.</p>
-      <!--<p>+ topic/keyword markup-d/markupname xml-d/xmlatt</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/xmlelement.dita
+++ b/specification/langRef/technicalContent/xmlelement.dita
@@ -26,7 +26,6 @@
           <xmlelement>markupname</xmlelement>; it is defined in the XML-mention domain module. The
           <xmlelement>markupname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>; it is defined in the markup-name domain module.</p>
-      <!--<p>+ topic/keyword markup-d/markupname xml-d/xmlelement</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/xmlnsname.dita
+++ b/specification/langRef/technicalContent/xmlnsname.dita
@@ -21,7 +21,6 @@
           <xmlelement>markupname</xmlelement>; it is defined in the XML-mention domain module. The
           <xmlelement>markupname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>; it is defined in the markup-name domain module.</p>
-      <!--<p>+ topic/keyword markup-d/markupname xml-d/xmlnsname</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/xmlpi.dita
+++ b/specification/langRef/technicalContent/xmlpi.dita
@@ -21,7 +21,6 @@
           <xmlelement>markupname</xmlelement>; it is defined in the XML-mention domain module. The
           <xmlelement>markupname</xmlelement> element is specialized from
           <xmlelement>keyword</xmlelement>; it is defined in the markup-name domain module.</p>
-      <!--<p>+ topic/keyword markup-d/markupname xml-d/xmlpi</p>-->
     </section>
     <section id="attributes">
       <title>Attributes</title>


### PR DESCRIPTION
Reformats "Specialization hierarchy" section of each tech-comm domain to match syntax now in use with the base.