### PR TITLE
Update example element model oasis-tcs/dita#297

### DIFF
--- a/doctypes/dtd/technicalContent/concept.mod
+++ b/doctypes/dtd/technicalContent/concept.mod
@@ -36,6 +36,16 @@
 <!--                    ELEMENT DECLARATIONS                       -->
 <!-- ============================================================= -->
 
+<!-- Based on body.cnt, but swaps
+     basic.block ==> basic.block.noexample-->
+<!ENTITY % conbody.cnt
+              "%basic.block.noexample; |
+               %data.elements.incl; |
+               %draft-comment; |
+               %foreign.unknown.incl; |
+               %required-cleanup;"
+>
+
 <!ENTITY % concept-info-types
               "%info-types;"
 >
@@ -72,7 +82,7 @@
 
 <!--                    LONG NAME: Concept Body                    -->
 <!ENTITY % conbody.content
-                       "((%body.cnt;)*,
+                       "((%conbody.cnt;)*,
                          (%section; |
                           %example; |
                           %conbodydiv;)*)"

--- a/doctypes/dtd/technicalContent/task.mod
+++ b/doctypes/dtd/technicalContent/task.mod
@@ -285,9 +285,20 @@
 <!ATTLIST  tutorialinfo %tutorialinfo.attributes;>
 
 
+<!-- Match itemgroup.cnt from base, but exclude example element    -->
+<!ENTITY % stepxmp.cnt
+              "#PCDATA |
+               %basic.block.noexample; |
+               %basic.ph; |
+               %data.elements.incl; |
+               %foreign.unknown.incl; |
+               %txt.incl;"
+>
+
+
 <!--                    LONG NAME: Step Example                    -->
 <!ENTITY % stepxmp.content
-                       "(%itemgroup.cnt;)*"
+                       "(%stepxmp.cnt;)*"
 >
 <!ENTITY % stepxmp.attributes
               "%univ-atts;"

--- a/doctypes/rng/technicalContent/conceptMod.rng
+++ b/doctypes/rng/technicalContent/conceptMod.rng
@@ -65,8 +65,22 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Concept//EN"
     <define name="conbodydiv">
       <ref name="conbodydiv.element"/>
     </define>
-
   </div>
+  
+  <div>
+    <a:documentation>COMMON CONTENT MODEL PATTERNS</a:documentation>
+    <!-- Matching body.cnt but remove example -->
+    <define name="conbody.cnt">
+      <choice>
+        <ref name="basic.block.noexample"/>
+        <ref name="data.elements.incl"/>
+        <ref name="draft-comment"/>
+        <ref name="foreign.unknown.incl"/>
+        <ref name="required-cleanup"/>
+     </choice>
+    </define>
+  </div>
+  
   <div>
     <a:documentation>ELEMENT TYPE DECLARATIONS</a:documentation>
 
@@ -129,7 +143,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Concept//EN"
       <a:documentation> LONG NAME: Concept Body </a:documentation>
       <define name="conbody.content">
         <zeroOrMore>
-          <ref name="body.cnt"/>
+          <ref name="conbody.cnt"/>
         </zeroOrMore>
         <zeroOrMore>
           <choice>

--- a/doctypes/rng/technicalContent/taskMod.rng
+++ b/doctypes/rng/technicalContent/taskMod.rng
@@ -170,6 +170,21 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
       <ref name="info-types"/>
     </define>
   </div>
+  
+  <div>
+    <a:documentation>COMMON CONTENT MODEL PATTERNS</a:documentation>
+    <!-- Match itemgroup.cnt but exclude example -->
+    <define name="stepxmp.cnt">
+      <choice>
+        <text/>
+        <ref name="basic.block.noexample"/>
+        <ref name="basic.ph"/>
+        <ref name="data.elements.incl"/>
+        <ref name="foreign.unknown.incl"/>
+        <ref name="txt.incl"/>
+      </choice>
+    </define>
+  </div>
   <div>
     <a:documentation>ELEMENT TYPE DECLARATIONS</a:documentation>
 
@@ -585,7 +600,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
       <a:documentation> LONG NAME: Step Example </a:documentation>
       <define name="stepxmp.content">
         <zeroOrMore>
-          <ref name="itemgroup.cnt"/>
+          <ref name="stepxmp.cnt"/>
         </zeroOrMore>
       </define>
       <define name="stepxmp.attributes">


### PR DESCRIPTION
* Update base spec submodule to get updates from https://github.com/oasis-tcs/dita/issues/297
* Ensure `conbody` content model remains valid as-is
* Exclude `example` from `stepxmp` element, which would otherwise get it as part of https://github.com/oasis-tcs/dita/issues/297