### PR TITLE
Remove duplicate definition of div entity

### DIFF
--- a/doctypes/dtd/technicalContent/concept.dtd
+++ b/doctypes/dtd/technicalContent/concept.dtd
@@ -158,9 +158,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -190,7 +187,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/ditabase.dtd
@@ -159,9 +159,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -191,7 +188,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/generalTask.dtd
+++ b/doctypes/dtd/technicalContent/generalTask.dtd
@@ -159,9 +159,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -191,7 +188,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/glossentry.dtd
+++ b/doctypes/dtd/technicalContent/glossentry.dtd
@@ -157,9 +157,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -189,7 +186,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/glossgroup.dtd
+++ b/doctypes/dtd/technicalContent/glossgroup.dtd
@@ -154,9 +154,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -186,7 +183,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/reference.dtd
+++ b/doctypes/dtd/technicalContent/reference.dtd
@@ -160,9 +160,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -192,7 +189,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/task.dtd
+++ b/doctypes/dtd/technicalContent/task.dtd
@@ -158,9 +158,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -190,7 +187,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/topic.dtd
+++ b/doctypes/dtd/technicalContent/topic.dtd
@@ -157,9 +157,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -189,7 +186,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->

--- a/doctypes/dtd/technicalContent/troubleshooting.dtd
+++ b/doctypes/dtd/technicalContent/troubleshooting.dtd
@@ -157,9 +157,6 @@
                          %pr-d-fig; |
                          %equation-d-fig;
                         ">
-<!ENTITY % div          "div |
-                         %ut-d-div;
-                        ">
 <!ENTITY % data         "data |
                          %ut-d-data;
                         ">
@@ -189,7 +186,8 @@
                          %mathml-d-foreign;
                         ">
 <!ENTITY % div          "div |
-                         %equation-d-div;
+                         %equation-d-div; |
+                         %ut-d-div;
                         ">
 
 <!-- ============================================================= -->


### PR DESCRIPTION
The `div` entity is declared twice, so the second is ignored. Probably a result of changes that integrated the revised model for image maps. Thanks @shudson310 for noticing...