### PR TITLE
Tweak keys to fix broken links, FOP process

### DIFF
--- a/specification/dita-2.0-technical-content-specification.ditamap
+++ b/specification/dita-2.0-technical-content-specification.ditamap
@@ -33,6 +33,7 @@
   <frontmatter>
     <topicref href="common/conref-cover-pages.dita" processing-role="resource-only"/>
     <mapref href="baseSpec/specification/common/key-definitions-library-topics.ditamap"/>
+    <mapref href="baseSpec/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap" format="ditamap"/>
     <mapref href="stubs/KeyStubs.ditamap" processing-role="resource-only"/>
     <!--    <mapref href="dita-20-key-definitions-common-metadata.ditamap" processing-role="resource-only"/>
     <mapref href="dita-20-key-definitions-part2-metadata.ditamap" processing-role="resource-only"/>-->

--- a/specification/langRef/bookmap-elements.ditamap
+++ b/specification/langRef/bookmap-elements.ditamap
@@ -42,7 +42,7 @@
             <topicref href="technicalContent/indexlist.dita" keys="indexlist" navtitle="indexlist"/>
             <topicref href="technicalContent/mainbooktitle.dita" keys="mainbooktitle"
                 navtitle="mainbooktitle"/>
-            <topicref href="technicalContent/notices.dita" keys="notices" navtitle="notices"/>
+            <topicref href="technicalContent/notices.dita" keys="elements-notices" navtitle="notices"/>
             <topicref href="technicalContent/part.dita" keys="part" navtitle="part"/>
             <topicref href="technicalContent/preface.dita" keys="preface" navtitle="preface"/>
             <topicref href="technicalContent/tablelist.dita" keys="tablelist" navtitle="tablelist"/>

--- a/specification/langRef/quick-reference/technicalContent-elements-a-to-z.dita
+++ b/specification/langRef/quick-reference/technicalContent-elements-a-to-z.dita
@@ -138,7 +138,7 @@
         <sli><xref keyref="msgnum"/></sli>
         <sli><xref keyref="msgph"/></sli>
         <sli><xref keyref="namedetails"/></sli>
-        <sli><xref keyref="notices"/></sli>
+        <sli><xref keyref="elements-notices"/></sli>
         <sli><xref keyref="numcharref"/></sli>
         <sli><xref keyref="oper"/></sli>
         <sli><xref keyref="option"/></sli>


### PR DESCRIPTION
Fixes a duplicate `notices` key, which resulted in a broken link that killed PDF (long term all element keys need the `elements-` prefix).

Import keys for the attribute topics, which fixes the same problem for elements that use attribute groups.

With these changes, I now get a PDF out of FOP using the OASIS spec style.