### PR TITLE
Remove deprecated navtitle from maps

### DIFF
--- a/specification/archSpec/archSpec-technicalContent.ditamap
+++ b/specification/archSpec/archSpec-technicalContent.ditamap
@@ -3,31 +3,28 @@
 <map xml:lang="en-us" collection-type="sequence">
  <title>Overview</title>
  <topicref href="archSpec-technicalContent.dita">
-  <topicref href="technicalContent/dita-technicalContent-InformationTypes.dita"
-   navtitle="Technical content: Information types">
+  <topicref href="technicalContent/dita-technicalContent-InformationTypes.dita">
+    <topicmeta>
+     <navtitle>Technical content: Information types</navtitle>
+    </topicmeta>
    <!--<topicref href="technicalContent/technicalContent-document-types.dita"/>-->
-   <topicref href="technicalContent/dita-spec-intro-bookmap.dita" navtitle="Bookmap"/>
-   <topicref href="technicalContent/dita-concept-topic.dita" navtitle="Concept topic"/>
-   <topicref href="technicalContent/dita-glossary-topic.dita" navtitle="Glossary Entry topic"/>
-   <topicref href="technicalContent/dita-glossarygroup-topic.dita" navtitle="Glossary Group topic"/>
-   <topicref href="technicalContent/dita-reference-topic.dita" navtitle="Reference topic"/>
-   <topicref href="technicalContent/dita-generic-task-topic.dita" navtitle="General task topic"/>
-   <topicref href="technicalContent/dita-task-topic.dita" navtitle="Task topic (strict)"/>
-   <topicref href="technicalContent/dita-troubleshooting-topic.dita"
-    navtitle="Troubleshooting topic">
-    <topicref href="technicalContent/TroubleshootingElements.dita"
-     navtitle="Troubleshooting elements"/>
+   <topicref href="technicalContent/dita-spec-intro-bookmap.dita"/>
+   <topicref href="technicalContent/dita-concept-topic.dita"/>
+   <topicref href="technicalContent/dita-glossary-topic.dita"/>
+   <topicref href="technicalContent/dita-glossarygroup-topic.dita"/>
+   <topicref href="technicalContent/dita-reference-topic.dita"/>
+   <topicref href="technicalContent/dita-generic-task-topic.dita"/>
+   <topicref href="technicalContent/dita-task-topic.dita"/>
+   <topicref href="technicalContent/dita-troubleshooting-topic.dita">
+    <topicref href="technicalContent/TroubleshootingElements.dita"/>
    </topicref>
   </topicref>
-  <topicref href="technicalContent/technical-content-domains.dita"
-   navtitle="Technical content domains">
-   <!--<topicref href="technicalContent/dita_technicalContent_TopicDomains.dita" navtitle="Topic domains: Technical content"/>-->
-   <topicref href="technicalContent/mathML-and-equation-domains.dita"
-    navtitle="MathML and equation domains"/>
-   <topicref href="technicalContent/releaseManagement-domain.dita"
-    navtitle="Release management domain"/>
-   <topicref href="technicalContent/xNALDomain.dita" navtitle="The xNAL domain">
-    <topicref href="technicalContent/xnaldetails.dita" navtitle="xNAL usage guidelines"/>
+  <topicref href="technicalContent/technical-content-domains.dita">
+   <!--<topicref href="technicalContent/dita_technicalContent_TopicDomains.dita"/>-->
+   <topicref href="technicalContent/mathML-and-equation-domains.dita"/>
+   <topicref href="technicalContent/releaseManagement-domain.dita"/>
+   <topicref href="technicalContent/xNALDomain.dita">
+    <topicref href="technicalContent/xnaldetails.dita"/>
    </topicref>
   </topicref>
  </topicref>

--- a/specification/dita-20-key-definitions-common-metadata.ditamap
+++ b/specification/dita-20-key-definitions-common-metadata.ditamap
@@ -3,7 +3,10 @@
 <map>
  <title>Key definitions for common metadata that is used in two or more of the specification
   editions</title>
- <topichead navtitle="OASIS naming fragments">
+ <topichead>
+  <topicmeta>
+   <navtitle>OASIS naming fragments</navtitle>
+  </topicmeta>
   <keydef keys="wp-abbrev">
    <topicmeta>
     <keywords>

--- a/specification/dita-20-key-definitions-cover-pages.ditamap
+++ b/specification/dita-20-key-definitions-cover-pages.ditamap
@@ -2,8 +2,10 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
   <title>Key definitions for the specification cover pages</title>
-
-  <topichead navtitle="Specification part titles">
+  <topichead>
+    <topicmeta>
+      <navtitle>Specification part titles</navtitle>
+    </topicmeta>
     <keydef keys="errata-title">
       <topicmeta>
         <keywords>
@@ -44,7 +46,10 @@
       </topicmeta>
     </keydef>
   </topichead>
-  <topichead navtitle="Link text and variable for file names">
+  <topichead>
+    <topicmeta>
+      <navtitle>Link text and variable for file names</navtitle>
+    </topicmeta>
     <!-- Date of specification approval -->
     <keydef keys="approval-date">
       <topicmeta>
@@ -80,7 +85,10 @@
       </topicmeta>
     </keydef>
   </topichead>
-  <topichead navtitle="This version">
+  <topichead>
+    <topicmeta>
+      <navtitle>This version</navtitle>
+    </topicmeta>
     <!-- THIS VERSION -->
     <keydef keys="spec-release-type">
       <topicmeta>
@@ -262,7 +270,10 @@
       </topicmeta>
     </keydef>
   </topichead>
-  <topichead navtitle="Previous version">
+  <topichead>
+    <topicmeta>
+      <navtitle>Previous version</navtitle>
+    </topicmeta>
     <!-- PREVIOUS VERSION -->
     <!-- Needs to have the previous OASIS metadata in @href and link text -->
     <keydef keys="previous-errata-html" href="http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/dita-v1.3-errata01-os-1-complete.html" scope="external"
@@ -350,7 +361,10 @@
       </topicmeta>
     </keydef>
   </topichead>
-  <topichead navtitle="Latest version">
+  <topichead>
+    <topicmeta>
+      <navtitle>Latest version</navtitle>
+    </topicmeta>
     <!-- LATEST VERSION -->
     <!-- Needs to have no OASIS metadata in @href and link text-->
     <!-- Do not change this as the specification advances through the different phases-->
@@ -437,7 +451,10 @@
     </keydef>
   </topichead>
 
-  <topichead navtitle="Related work">
+  <topichead>
+    <topicmeta>
+      <navtitle>Related work</navtitle>
+    </topicmeta>
     <!-- RELATED WORK -->
     <!-- Needs to have no OASIS metadata in @href and link text-->
     <!--Part 0: Overview -->

--- a/specification/dita-20-key-definitions-part2-metadata.ditamap
+++ b/specification/dita-20-key-definitions-part2-metadata.ditamap
@@ -2,7 +2,10 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>Key definitions for part1</title>
- <topichead navtitle="Common Oasis namimg fragments">
+ <topichead>
+  <topicmeta>
+   <navtitle>Common OASIS naming fragments</navtitle>
+  </topicmeta>
   <keydef keys="part-number">
    <topicmeta>
     <keywords>

--- a/specification/langRef/bookmap-elements.ditamap
+++ b/specification/langRef/bookmap-elements.ditamap
@@ -2,103 +2,73 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
     <title>Bookmap elements</title>
-    <topicref href="containers/bookmap-elements.dita" navtitle="Bookmap elements">
+    <topicref href="containers/bookmap-elements.dita">
         <!--Bookmap content elements -->
-        <topicref href="containers/bookmap-content-elements.dita"
-            navtitle="Bookmap content elements">
-            <topicref href="technicalContent/abbrevlist.dita" keys="abbrevlist"
-                navtitle="abbrevlist"/>
-            <topicref href="technicalContent/amendments.dita" keys="amendments"
-                navtitle="amendments"/>
-            <topicref href="technicalContent/appendices.dita" keys="appendices"
-                navtitle="appendices"/>
-            <topicref href="technicalContent/appendix.dita" keys="appendix" navtitle="appendix"/>
-            <topicref href="technicalContent/bookmap.dita" keys="bookmap" navtitle="bookmap"/>
-            <topicref href="technicalContent/backmatter.dita" keys="backmatter"
-                navtitle="backmatter"/>
-            <topicref href="technicalContent/bibliolist.dita" keys="bibliolist"
-                navtitle="bibliolist"/>
-            <topicref href="technicalContent/bookabstract.dita" keys="bookabstract"
-                navtitle="bookabstract"/>
-            <topicref href="technicalContent/booklibrary.dita" keys="booklibrary"
-                navtitle="booklibrary"/>
-            <topicref href="technicalContent/booklist.dita" keys="booklist" navtitle="booklist"/>
-            <topicref href="technicalContent/booklists.dita" keys="booklists" navtitle="booklists"/>
-            <topicref href="technicalContent/booktitle.dita" keys="booktitle" navtitle="booktitle"/>
-            <topicref href="technicalContent/booktitlealt.dita" keys="booktitlealt"
-                navtitle="booktitlealt"/>
-            <topicref href="technicalContent/chapter.dita" keys="chapter" navtitle="chapter"/>
-            <topicref href="technicalContent/colophon.dita" keys="colophon" navtitle="colophon"/>
-            <topicref href="technicalContent/dedication.dita" keys="dedication"
-                navtitle="dedication"/>
-            <topicref href="technicalContent/draftintro.dita" keys="draftintro"
-                navtitle="draftintro"/>
-            <topicref href="technicalContent/figurelist.dita" keys="figurelist"
-                navtitle="figurelist"/>
-            <topicref href="technicalContent/frontmatter.dita" keys="frontmatter"
-                navtitle="frontmatter"/>
-            <topicref href="technicalContent/glossarylist.dita" keys="glossarylist"
-                navtitle="glossarylist"/>
-            <topicref href="technicalContent/indexlist.dita" keys="indexlist" navtitle="indexlist"/>
-            <topicref href="technicalContent/mainbooktitle.dita" keys="mainbooktitle"
-                navtitle="mainbooktitle"/>
-            <topicref href="technicalContent/notices.dita" keys="elements-notices" navtitle="notices"/>
-            <topicref href="technicalContent/part.dita" keys="part" navtitle="part"/>
-            <topicref href="technicalContent/preface.dita" keys="preface" navtitle="preface"/>
-            <topicref href="technicalContent/tablelist.dita" keys="tablelist" navtitle="tablelist"/>
-            <topicref href="technicalContent/toc.dita" keys="toc" navtitle="toc"/>
-            <topicref href="technicalContent/trademarklist.dita" keys="trademarklist"
-                navtitle="trademarklist"/>
+        <topicref href="containers/bookmap-content-elements.dita">
+            <topicref href="technicalContent/abbrevlist.dita" keys="abbrevlist"/>
+            <topicref href="technicalContent/amendments.dita" keys="amendments"/>
+            <topicref href="technicalContent/appendices.dita" keys="appendices"/>
+            <topicref href="technicalContent/appendix.dita" keys="appendix"/>
+            <topicref href="technicalContent/bookmap.dita" keys="bookmap"/>
+            <topicref href="technicalContent/backmatter.dita" keys="backmatter"/>
+            <topicref href="technicalContent/bibliolist.dita" keys="bibliolist"/>
+            <topicref href="technicalContent/bookabstract.dita" keys="bookabstract"/>
+            <topicref href="technicalContent/booklibrary.dita" keys="booklibrary"/>
+            <topicref href="technicalContent/booklist.dita" keys="booklist"/>
+            <topicref href="technicalContent/booklists.dita" keys="booklists"/>
+            <topicref href="technicalContent/booktitle.dita" keys="booktitle"/>
+            <topicref href="technicalContent/booktitlealt.dita" keys="booktitlealt"/>
+            <topicref href="technicalContent/chapter.dita" keys="chapter"/>
+            <topicref href="technicalContent/colophon.dita" keys="colophon"/>
+            <topicref href="technicalContent/dedication.dita" keys="dedication"/>
+            <topicref href="technicalContent/draftintro.dita" keys="draftintro"/>
+            <topicref href="technicalContent/figurelist.dita" keys="figurelist"/>
+            <topicref href="technicalContent/frontmatter.dita" keys="frontmatter"/>
+            <topicref href="technicalContent/glossarylist.dita" keys="glossarylist"/>
+            <topicref href="technicalContent/indexlist.dita" keys="indexlist"/>
+            <topicref href="technicalContent/mainbooktitle.dita" keys="mainbooktitle"/>
+            <topicref href="technicalContent/notices.dita" keys="elements-notices"/>
+            <topicref href="technicalContent/part.dita" keys="part"/>
+            <topicref href="technicalContent/preface.dita" keys="preface"/>
+            <topicref href="technicalContent/tablelist.dita" keys="tablelist"/>
+            <topicref href="technicalContent/toc.dita" keys="toc"/>
+            <topicref href="technicalContent/trademarklist.dita" keys="trademarklist"/>
         </topicref>
         <!--Bookmap metadata elements -->
-        <topicref href="containers/bookmap-metadata-elements.dita"
-            navtitle="Bookmap metadata elements">
-            <topicref href="technicalContent/approved.dita" keys="approved" navtitle="approved"/>
-            <topicref href="technicalContent/bookchangehistory.dita" keys="bookchangehistory"
-                navtitle="bookchangehistory"/>
-            <topicref href="technicalContent/bookevent.dita" keys="bookevent" navtitle="bookevent"/>
-            <topicref href="technicalContent/bookeventtype.dita" keys="bookeventtype"
-                navtitle="bookeventtype"/>
-            <topicref href="technicalContent/bookid.dita" keys="bookid" navtitle="bookid"/>
-            <topicref href="technicalContent/bookmeta.dita" keys="bookmeta" navtitle="bookmeta"/>
-            <topicref href="technicalContent/booknumber.dita" keys="booknumber"
-                navtitle="booknumber"/>
-            <topicref href="technicalContent/bookowner.dita" keys="bookowner" navtitle="bookowner"/>
-            <topicref href="technicalContent/bookpartno.dita" keys="bookpartno"
-                navtitle="bookpartno"/>
-            <topicref href="technicalContent/bookrestriction.dita" keys="bookrestriction"
-                navtitle="bookrestriction"/>
-            <topicref href="technicalContent/bookrights.dita" keys="bookrights"
-                navtitle="bookrights"/>
-            <topicref href="technicalContent/completed.dita" keys="completed" navtitle="completed"/>
-            <topicref href="technicalContent/copyrfirst.dita" keys="copyrfirst"
-                navtitle="copyrfirst"/>
-            <topicref href="technicalContent/copyrlast.dita" keys="copyrlast" navtitle="copyrlast"/>
-            <topicref href="technicalContent/day.dita" keys="day" navtitle="day"/>
-            <topicref href="technicalContent/edited.dita" keys="edited" navtitle="edited"/>
-            <topicref href="technicalContent/edition.dita" keys="edition" navtitle="edition"/>
-            <topicref href="technicalContent/isbn.dita" keys="isbn" navtitle="isbn"/>
-            <topicref href="technicalContent/maintainer.dita" keys="maintainer"
-                navtitle="maintainer"/>
-            <topicref href="technicalContent/month.dita" keys="month" navtitle="month"/>
-            <topicref href="technicalContent/organization.dita" keys="organization"
-                navtitle="organization"/>
-            <topicref href="technicalContent/person.dita" keys="person" navtitle="person"/>
-            <topicref href="technicalContent/printlocation.dita" keys="printlocation"
-                navtitle="printlocation"/>
-            <topicref href="technicalContent/published.dita" keys="published" navtitle="published"/>
-            <topicref href="technicalContent/publisherinformation.dita" keys="publisherinformation"
-                navtitle="publisherinformation"/>
-            <topicref href="technicalContent/publishtype.dita" keys="publishtype"
-                navtitle="publishtype"/>
-            <topicref href="technicalContent/reviewed.dita" keys="reviewed" navtitle="reviewed"/>
-            <topicref href="technicalContent/revisionid.dita" keys="revisionid"
-                navtitle="revisionid"/>
-            <topicref href="technicalContent/started.dita" keys="started" navtitle="started"/>
-            <topicref href="technicalContent/summary.dita" keys="summary" navtitle="summary"/>
-            <topicref href="technicalContent/tested.dita" keys="tested" navtitle="tested"/>
-            <topicref href="technicalContent/volume.dita" keys="volume" navtitle="volume"/>
-            <topicref href="technicalContent/year.dita" keys="year" navtitle="year"/>
+        <topicref href="containers/bookmap-metadata-elements.dita">
+            <topicref href="technicalContent/approved.dita" keys="approved"/>
+            <topicref href="technicalContent/bookchangehistory.dita" keys="bookchangehistory"/>
+            <topicref href="technicalContent/bookevent.dita" keys="bookevent"/>
+            <topicref href="technicalContent/bookeventtype.dita" keys="bookeventtype"/>
+            <topicref href="technicalContent/bookid.dita" keys="bookid"/>
+            <topicref href="technicalContent/bookmeta.dita" keys="bookmeta"/>
+            <topicref href="technicalContent/booknumber.dita" keys="booknumber"/>
+            <topicref href="technicalContent/bookowner.dita" keys="bookowner"/>
+            <topicref href="technicalContent/bookpartno.dita" keys="bookpartno"/>
+            <topicref href="technicalContent/bookrestriction.dita" keys="bookrestriction"/>
+            <topicref href="technicalContent/bookrights.dita" keys="bookrights"/>
+            <topicref href="technicalContent/completed.dita" keys="completed"/>
+            <topicref href="technicalContent/copyrfirst.dita" keys="copyrfirst"/>
+            <topicref href="technicalContent/copyrlast.dita" keys="copyrlast"/>
+            <topicref href="technicalContent/day.dita" keys="day"/>
+            <topicref href="technicalContent/edited.dita" keys="edited"/>
+            <topicref href="technicalContent/edition.dita" keys="edition"/>
+            <topicref href="technicalContent/isbn.dita" keys="isbn"/>
+            <topicref href="technicalContent/maintainer.dita" keys="maintainer"/>
+            <topicref href="technicalContent/month.dita" keys="month"/>
+            <topicref href="technicalContent/organization.dita" keys="organization"/>
+            <topicref href="technicalContent/person.dita" keys="person"/>
+            <topicref href="technicalContent/printlocation.dita" keys="printlocation"/>
+            <topicref href="technicalContent/published.dita" keys="published"/>
+            <topicref href="technicalContent/publisherinformation.dita" keys="publisherinformation"/>
+            <topicref href="technicalContent/publishtype.dita" keys="publishtype"/>
+            <topicref href="technicalContent/reviewed.dita" keys="reviewed"/>
+            <topicref href="technicalContent/revisionid.dita" keys="revisionid"/>
+            <topicref href="technicalContent/started.dita" keys="started"/>
+            <topicref href="technicalContent/summary.dita" keys="summary"/>
+            <topicref href="technicalContent/tested.dita" keys="tested"/>
+            <topicref href="technicalContent/volume.dita" keys="volume"/>
+            <topicref href="technicalContent/year.dita" keys="year"/>
         </topicref>
     </topicref>
 </map>

--- a/specification/langRef/concept-elements.ditamap
+++ b/specification/langRef/concept-elements.ditamap
@@ -2,10 +2,10 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>Concept elements</title>
- <topicref href="containers/concept-elements.dita" navtitle="Concept elements">
+ <topicref href="containers/concept-elements.dita">
   <?Pub Dtl?>
-  <topicref href="technicalContent/concept.dita" keys="concept" navtitle="concept"/>
-  <topicref href="technicalContent/conbody.dita" keys="conbody" navtitle="conbody"/>
-  <topicref href="technicalContent/conbodydiv.dita" keys="conbodydiv" navtitle="conbodydiv"/>
+  <topicref href="technicalContent/concept.dita" keys="concept"/>
+  <topicref href="technicalContent/conbody.dita" keys="conbody"/>
+  <topicref href="technicalContent/conbodydiv.dita" keys="conbodydiv"/>
  </topicref>
 </map>

--- a/specification/langRef/equation-domain-elements.ditamap
+++ b/specification/langRef/equation-domain-elements.ditamap
@@ -2,14 +2,14 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
     <title>Equation domain elements</title>
-    <topicref href="containers/equation-elements.dita" navtitle="Equation domain elements">
-        <topicref href="technicalContent/equation-block.dita" navtitle="equation-block"
+    <topicref href="containers/equation-elements.dita">
+        <topicref href="technicalContent/equation-block.dita"
             keys="equation-block"/>
-        <topicref href="technicalContent/equation-figure.dita" navtitle="equation-figure"
+        <topicref href="technicalContent/equation-figure.dita"
             keys="equation-figure"/>
-        <topicref href="technicalContent/equation-inline.dita" navtitle="equation-inline"
+        <topicref href="technicalContent/equation-inline.dita"
             keys="equation-inline"/>
-        <topicref href="technicalContent/equation-number.dita" navtitle="equation-number"
+        <topicref href="technicalContent/equation-number.dita"
             keys="equation-number"/>
     </topicref>
 </map>

--- a/specification/langRef/markup-domain-elements.ditamap
+++ b/specification/langRef/markup-domain-elements.ditamap
@@ -2,7 +2,7 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
     <title>Markup domain elements</title>
-    <topicref href="containers/markup-domain.dita" navtitle="Markup domain">
-        <topicref href="technicalContent/markupname.dita" navtitle="markupname" keys="markupname"/>
+    <topicref href="containers/markup-domain.dita">
+        <topicref href="technicalContent/markupname.dita" keys="markupname"/>
     </topicref>
 </map>

--- a/specification/langRef/mathml-domain-elements.ditamap
+++ b/specification/langRef/mathml-domain-elements.ditamap
@@ -2,8 +2,8 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
     <title>MathML domain elements</title>
-    <topicref href="containers/mathml-d.dita" navtitle="MathML domain elements">
-        <topicref href="technicalContent/mathml.dita" navtitle="mathml" keys="mathml"/>
-        <topicref href="technicalContent/mathmlref.dita" navtitle="mathmlref" keys="mathmlref"/>
+    <topicref href="containers/mathml-d.dita">
+        <topicref href="technicalContent/mathml.dita" keys="mathml"/>
+        <topicref href="technicalContent/mathmlref.dita" keys="mathmlref"/>
     </topicref>
 </map>

--- a/specification/langRef/reference-elements.ditamap
+++ b/specification/langRef/reference-elements.ditamap
@@ -2,19 +2,19 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>Reference elements</title>
- <topicref href="containers/reference-elements.dita" navtitle="Reference elements">
-  <topicref href="technicalContent/reference.dita" keys="reference" navtitle="reference"/>
-  <topicref href="technicalContent/refbody.dita" keys="refbody" navtitle="refbody"/>
-  <topicref href="technicalContent/refbodydiv.dita" keys="refbodydiv" navtitle="refbodydiv"/>
-  <topicref href="technicalContent/refsyn.dita" keys="refsyn" navtitle="refsyn"/>
-  <topicref href="technicalContent/properties.dita" keys="properties" navtitle="properties"/>
-  <topicref href="technicalContent/prophead.dita" keys="prophead" navtitle="prophead"/>
-  <topicref href="technicalContent/proptypehd.dita" keys="proptypehd" navtitle="proptypehd"/>
-  <topicref href="technicalContent/propvaluehd.dita" keys="propvaluehd" navtitle="propvaluehd"/>
-  <topicref href="technicalContent/propdeschd.dita" keys="propdeschd" navtitle="propdeschd"/>
-  <topicref href="technicalContent/property.dita" keys="property" navtitle="property"/>
-  <topicref href="technicalContent/proptype.dita" keys="proptype" navtitle="proptype"/>
-  <topicref href="technicalContent/propvalue.dita" keys="propvalue" navtitle="propvalue"/>
-  <topicref href="technicalContent/propdesc.dita" keys="propdesc" navtitle="propdesc"/>
+ <topicref href="containers/reference-elements.dita">
+  <topicref href="technicalContent/reference.dita" keys="reference"/>
+  <topicref href="technicalContent/refbody.dita" keys="refbody"/>
+  <topicref href="technicalContent/refbodydiv.dita" keys="refbodydiv"/>
+  <topicref href="technicalContent/refsyn.dita" keys="refsyn"/>
+  <topicref href="technicalContent/properties.dita" keys="properties"/>
+  <topicref href="technicalContent/prophead.dita" keys="prophead"/>
+  <topicref href="technicalContent/proptypehd.dita" keys="proptypehd"/>
+  <topicref href="technicalContent/propvaluehd.dita" keys="propvaluehd"/>
+  <topicref href="technicalContent/propdeschd.dita" keys="propdeschd"/>
+  <topicref href="technicalContent/property.dita" keys="property"/>
+  <topicref href="technicalContent/proptype.dita" keys="proptype"/>
+  <topicref href="technicalContent/propvalue.dita" keys="propvalue"/>
+  <topicref href="technicalContent/propdesc.dita" keys="propdesc"/>
  </topicref>
 </map>

--- a/specification/langRef/release-management-domain-elements.ditamap
+++ b/specification/langRef/release-management-domain-elements.ditamap
@@ -2,8 +2,7 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>Release-management domain elements</title>
- <topicref href="containers/Release-management-domain-elements.dita"
-  navtitle="Release-management domain elements" >
+ <topicref href="containers/Release-management-domain-elements.dita" >
   <topicref href="technicalContent/change-completed.dita" keys="change-completed"
    />
   <topicref href="technicalContent/change-historylist.dita" keys="change-historylist"

--- a/specification/langRef/software-domain-elements.ditamap
+++ b/specification/langRef/software-domain-elements.ditamap
@@ -2,14 +2,14 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>Software domain elements</title>
- <topicref href="containers/sw-d.dita" navtitle="Software elements">
-  <topicref href="technicalContent/msgph.dita" keys="msgph" navtitle="msgph"/>
-  <topicref href="technicalContent/msgblock.dita" keys="msgblock" navtitle="msgblock"/>
-  <topicref href="technicalContent/msgnum.dita" keys="msgnum" navtitle="msgnum"/>
-  <topicref href="technicalContent/cmdname.dita" keys="cmdname" navtitle="cmdname"/>
-  <topicref href="technicalContent/varname.dita" keys="varname" navtitle="varname"/>
-  <topicref href="technicalContent/filepath.dita" keys="filepath" navtitle="filepath"/>
-  <topicref href="technicalContent/userinput.dita" keys="userinput" navtitle="userinput"/>
-  <topicref href="technicalContent/systemoutput.dita" keys="systemoutput" navtitle="systemoutput"/>
+ <topicref href="containers/sw-d.dita">
+  <topicref href="technicalContent/msgph.dita" keys="msgph"/>
+  <topicref href="technicalContent/msgblock.dita" keys="msgblock"/>
+  <topicref href="technicalContent/msgnum.dita" keys="msgnum"/>
+  <topicref href="technicalContent/cmdname.dita" keys="cmdname"/>
+  <topicref href="technicalContent/varname.dita" keys="varname"/>
+  <topicref href="technicalContent/filepath.dita" keys="filepath"/>
+  <topicref href="technicalContent/userinput.dita" keys="userinput"/>
+  <topicref href="technicalContent/systemoutput.dita" keys="systemoutput"/>
  </topicref>
 </map>

--- a/specification/langRef/svg-domain-elements.ditamap
+++ b/specification/langRef/svg-domain-elements.ditamap
@@ -2,7 +2,7 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
     <title>SVG domain elements</title>
-    <topicref href="containers/SVG-elements.dita" navtitle="SVG elements">
+    <topicref href="containers/SVG-elements.dita">
         <topicref href="technicalContent/svg-container.dita" keys="svg-container"/>
         <topicref href="technicalContent/svgref.dita" keys="svgref"/>
     </topicref>

--- a/specification/langRef/troubleshooting-elements.ditamap
+++ b/specification/langRef/troubleshooting-elements.ditamap
@@ -2,7 +2,7 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>Troubleshooting elements</title>
- <topicref href="containers/troubleshooting-elements.dita" navtitle="Troubleshooting elements"
+ <topicref href="containers/troubleshooting-elements.dita"
   >
   <topicref href="technicalContent/troubleshooting.dita" keys="troubleshooting"
    />

--- a/specification/langRef/ui-domain-elements.ditamap
+++ b/specification/langRef/ui-domain-elements.ditamap
@@ -2,11 +2,11 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>User-interface domain elements</title>
- <topicref href="containers/ui-d.dita" navtitle="User interface elements">
-  <topicref href="technicalContent/uicontrol.dita" keys="uicontrol" navtitle="uicontrol"/>
-  <topicref href="technicalContent/wintitle.dita" keys="wintitle" navtitle="wintitle"/>
-  <topicref href="technicalContent/menucascade.dita" keys="menucascade" navtitle="menucascade"/>
-  <topicref href="technicalContent/shortcut.dita" keys="shortcut" navtitle="shortcut"/>
-  <topicref href="technicalContent/screen.dita" keys="screen" navtitle="screen"/>
+ <topicref href="containers/ui-d.dita">
+  <topicref href="technicalContent/uicontrol.dita" keys="uicontrol"/>
+  <topicref href="technicalContent/wintitle.dita" keys="wintitle"/>
+  <topicref href="technicalContent/menucascade.dita" keys="menucascade"/>
+  <topicref href="technicalContent/shortcut.dita" keys="shortcut"/>
+  <topicref href="technicalContent/screen.dita" keys="screen"/>
  </topicref>
 </map>

--- a/specification/langRef/xml-mention-domain-elements.ditamap
+++ b/specification/langRef/xml-mention-domain-elements.ditamap
@@ -2,21 +2,20 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
  <title>XML-mention domain elements</title>
- <topicref href="containers/xml-mention-domain.dita" 
-  navtitle="XML mention domain">
-  <topicref href="technicalContent/numcharref.dita" navtitle="numcharref" keys="numcharref"
+ <topicref href="containers/xml-mention-domain.dita">
+  <topicref href="technicalContent/numcharref.dita" keys="numcharref"
    />
-  <topicref href="technicalContent/parameterentity.dita" navtitle="parameterentity"
+  <topicref href="technicalContent/parameterentity.dita"
    keys="parameterentity" />
-  <topicref href="technicalContent/textentity.dita" navtitle="textentity" keys="textentity"
+  <topicref href="technicalContent/textentity.dita" keys="textentity"
    />
-  <topicref href="technicalContent/xmlatt.dita" navtitle="xmlatt" keys="xmlatt"
+  <topicref href="technicalContent/xmlatt.dita" keys="xmlatt"
    />
-  <topicref href="technicalContent/xmlelement.dita" navtitle="xmlelement" keys="xmlelement"
+  <topicref href="technicalContent/xmlelement.dita" keys="xmlelement"
    />
-  <topicref href="technicalContent/xmlnsname.dita" navtitle="xmlnsname" keys="xmlnsname"
+  <topicref href="technicalContent/xmlnsname.dita" keys="xmlnsname"
    />
-  <topicref href="technicalContent/xmlpi.dita" navtitle="xmlpi" keys="xmlpi"
+  <topicref href="technicalContent/xmlpi.dita" keys="xmlpi"
    />
  </topicref>
 </map>

--- a/specification/langRef/xnal-domain-elements.ditamap
+++ b/specification/langRef/xnal-domain-elements.ditamap
@@ -2,45 +2,33 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
     <title>XNAL domain elements</title>
-    <topicref href="containers/xnal-d.dita" navtitle="xNAL domain elements">
-        <topicref href="technicalContent/authorinformation.dita" keys="authorinformation"
-            navtitle="authorinformation"/>
-        <topicref href="technicalContent/addressdetails.dita" keys="addressdetails"
-            navtitle="addressdetails"/>
-        <topicref href="technicalContent/administrativearea.dita" keys="administrativearea"
-            navtitle="administrativearea"/>
-        <topicref href="technicalContent/contactnumber.dita" keys="contactnumber"
-            navtitle="contactnumber"/>
-        <topicref href="technicalContent/contactnumbers.dita" keys="contactnumbers"
-            navtitle="contactnumbers"/>
-        <topicref href="technicalContent/country.dita" keys="country" navtitle="country"/>
-        <topicref href="technicalContent/emailaddress.dita" keys="emailaddress"
-            navtitle="emailaddress"/>
-        <topicref href="technicalContent/emailaddresses.dita" keys="emailaddresses"
-            navtitle="emailaddresses"/>
-        <topicref href="technicalContent/firstname.dita" keys="firstname" navtitle="firstname"/>
-        <topicref href="technicalContent/generationidentifier.dita" keys="generationidentifier"
-            navtitle="generationidentifier"/>
-        <topicref href="technicalContent/honorific.dita" keys="honorific" navtitle="honorific"/>
-        <topicref href="technicalContent/lastname.dita" keys="lastname" navtitle="lastname"/>
-        <topicref href="technicalContent/locality.dita" keys="locality" navtitle="locality"/>
-        <topicref href="technicalContent/localityname.dita" keys="localityname"
-            navtitle="localityname"/>
-        <topicref href="technicalContent/middlename.dita" keys="middlename" navtitle="middlename"/>
-        <topicref href="technicalContent/namedetails.dita" keys="namedetails" navtitle="namedetails"/>
-        <topicref href="technicalContent/organizationinfo.dita" keys="organizationinfo"
-            navtitle="organizationinfo"/>
-        <topicref href="technicalContent/organizationname.dita" keys="organizationname"
-            navtitle="organizationname"/>
+    <topicref href="containers/xnal-d.dita">
+        <topicref href="technicalContent/authorinformation.dita" keys="authorinformation"/>
+        <topicref href="technicalContent/addressdetails.dita" keys="addressdetails"/>
+        <topicref href="technicalContent/administrativearea.dita" keys="administrativearea"/>
+        <topicref href="technicalContent/contactnumber.dita" keys="contactnumber"/>
+        <topicref href="technicalContent/contactnumbers.dita" keys="contactnumbers"/>
+        <topicref href="technicalContent/country.dita" keys="country"/>
+        <topicref href="technicalContent/emailaddress.dita" keys="emailaddress"/>
+        <topicref href="technicalContent/emailaddresses.dita" keys="emailaddresses"/>
+        <topicref href="technicalContent/firstname.dita" keys="firstname"/>
+        <topicref href="technicalContent/generationidentifier.dita" keys="generationidentifier"/>
+        <topicref href="technicalContent/honorific.dita" keys="honorific"/>
+        <topicref href="technicalContent/lastname.dita" keys="lastname"/>
+        <topicref href="technicalContent/locality.dita" keys="locality"/>
+        <topicref href="technicalContent/localityname.dita" keys="localityname"/>
+        <topicref href="technicalContent/middlename.dita" keys="middlename"/>
+        <topicref href="technicalContent/namedetails.dita" keys="namedetails"/>
+        <topicref href="technicalContent/organizationinfo.dita" keys="organizationinfo"/>
+        <topicref href="technicalContent/organizationname.dita" keys="organizationname"/>
         <topicref href="technicalContent/organizationnamedetails.dita"
-            keys="organizationnamedetails" navtitle="organizationnamedetails"/>
-        <topicref href="technicalContent/otherinfo.dita" keys="otherinfo" navtitle="otherinfo"/>
-        <topicref href="technicalContent/personinfo.dita" keys="personinfo" navtitle="personinfo"/>
-        <topicref href="technicalContent/personname.dita" keys="personname" navtitle="personname"/>
-        <topicref href="technicalContent/postalcode.dita" keys="postalcode" navtitle="postalcode"/>
-        <topicref href="technicalContent/thoroughfare.dita" keys="thoroughfare"
-            navtitle="thoroughfare"/>
-        <topicref href="technicalContent/url.dita" keys="url" navtitle="url"/>
-        <topicref href="technicalContent/urls.dita" keys="urls" navtitle="urls"/>
+            keys="organizationnamedetails"/>
+        <topicref href="technicalContent/otherinfo.dita" keys="otherinfo"/>
+        <topicref href="technicalContent/personinfo.dita" keys="personinfo"/>
+        <topicref href="technicalContent/personname.dita" keys="personname"/>
+        <topicref href="technicalContent/postalcode.dita" keys="postalcode"/>
+        <topicref href="technicalContent/thoroughfare.dita" keys="thoroughfare"/>
+        <topicref href="technicalContent/url.dita" keys="url"/>
+        <topicref href="technicalContent/urls.dita" keys="urls"/>
     </topicref>
 </map>


### PR DESCRIPTION
Where the navtitle seems useful, move it to `<navtitle>`

Otherwise, drop `@navtitle`