### PR TITLE
Remove data-about element oasis-tcs/dita#372

### DIFF
--- a/doctypes/dtd/technicalContent/mathmlDomain.mod
+++ b/doctypes/dtd/technicalContent/mathmlDomain.mod
@@ -68,8 +68,7 @@
 <!ENTITY % mathml.content
                        "(m:math |
                          %mathmlref; |
-                         %data; |
-                         %data-about;)*"
+                         %data;)*"
 >
 <!ENTITY % mathml.attributes
               "%univ-atts;"

--- a/doctypes/dtd/technicalContent/programmingDomain.mod
+++ b/doctypes/dtd/technicalContent/programmingDomain.mod
@@ -166,8 +166,7 @@
 
 <!--                    LONG NAME: Parameter List                  -->
 <!ENTITY % parml.content
-                       "((%data; |
-                          %data-about;)*,
+                       "((%data;)*,
                          (%plentry;)+)"
 >
 <!ENTITY % parml.attributes

--- a/doctypes/dtd/technicalContent/svgDomain.mod
+++ b/doctypes/dtd/technicalContent/svgDomain.mod
@@ -26,8 +26,7 @@
 <!ENTITY % svg-container.content
                        "(svg:svg |
                          %svgref; |
-                         %data; |
-                         %data-about;)*"
+                         %data;)*"
 >
 <!ENTITY % svg-container.attributes
               "%univ-atts;"

--- a/doctypes/dtd/technicalContent/task.mod
+++ b/doctypes/dtd/technicalContent/task.mod
@@ -185,8 +185,7 @@
 
 <!--                    LONG NAME: Steps                           -->
 <!ENTITY % steps.content
-                       "((%data; |
-                          %data-about;)*,
+                       "((%data;)*,
                          ((%stepsection;)?,
                           (%step;))+)"
 >
@@ -199,8 +198,7 @@
 
 <!--                    LONG NAME: Unordered steps                 -->
 <!ENTITY % steps-unordered.content
-                       "((%data; |
-                          %data-about;)*,
+                       "((%data;)*,
                          ((%stepsection;)?,
                           (%step;))+)"
 >
@@ -309,8 +307,7 @@
 
 <!--                    LONG NAME: Choices                         -->
 <!ENTITY % choices.content
-                       "((%data; |
-                          %data-about;)*,
+                       "((%data;)*,
                          (%choice;)+)"
 >
 <!ENTITY % choices.attributes

--- a/doctypes/rng/technicalContent/mathmlDomain.rng
+++ b/doctypes/rng/technicalContent/mathmlDomain.rng
@@ -170,7 +170,6 @@ elements
             />
             <ref name="mathmlref"/>
             <ref name="data"/>
-            <ref name="data-about"/>
           </choice>
         </zeroOrMore>
       </define>

--- a/doctypes/rng/technicalContent/programmingDomain.rng
+++ b/doctypes/rng/technicalContent/programmingDomain.rng
@@ -320,11 +320,8 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Programming Domain//EN"
     <div>
       <a:documentation> LONG NAME: Parameter List </a:documentation>
       <define name="parml.content">
-        <zeroOrMore dita:since="1.3">
-          <choice>
-            <ref name="data"/>
-            <ref name="data-about"/>
-          </choice>
+        <zeroOrMore>
+          <ref name="data"/>
         </zeroOrMore>
         <oneOrMore>
           <ref name="plentry"/>

--- a/doctypes/rng/technicalContent/svgDomain.rng
+++ b/doctypes/rng/technicalContent/svgDomain.rng
@@ -61,7 +61,6 @@ DITA SVG Domain
             </externalRef>
             <ref name="svgref"/>
             <ref name="data"/>
-            <ref name="data-about"/>
           </choice>
         </zeroOrMore>
       </define>

--- a/doctypes/rng/technicalContent/taskMod.rng
+++ b/doctypes/rng/technicalContent/taskMod.rng
@@ -371,11 +371,8 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
     <div>
       <a:documentation> LONG NAME: Steps </a:documentation>
       <define name="steps.content">
-        <zeroOrMore dita:since="1.3">
-          <choice>
-            <ref name="data"/>
-            <ref name="data-about"/>
-          </choice>
+        <zeroOrMore>
+          <ref name="data"/>
         </zeroOrMore>
         <oneOrMore>
           <optional>
@@ -407,11 +404,8 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
     <div>
       <a:documentation> LONG NAME: Steps: Unordered </a:documentation>
       <define name="steps-unordered.content">
-        <zeroOrMore dita:since="1.3">
-          <choice>
-            <ref name="data"/>
-            <ref name="data-about"/>
-          </choice>
+        <zeroOrMore>
+          <ref name="data"/>
         </zeroOrMore>
         <oneOrMore>
           <optional>
@@ -621,11 +615,8 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
     <div>
       <a:documentation> LONG NAME: Choices </a:documentation>
       <define name="choices.content">
-        <zeroOrMore dita:since="1.3">
-          <choice>
-            <ref name="data"/>
-            <ref name="data-about"/>
-          </choice>
+        <zeroOrMore>
+          <ref name="data"/>
         </zeroOrMore>
         <oneOrMore>
           <ref name="choice"/>

--- a/specification/langRef/technicalContent/mathml.dita
+++ b/specification/langRef/technicalContent/mathml.dita
@@ -15,8 +15,7 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p>MathML element content includes MathML elements, references to MathML elements held in separate,
-        non-DITA documents, <xmlelement>data</xmlelement>, or <xmlelement>data-about</xmlelement>
-        elements.</p>
+        non-DITA documents, or <xmlelement>data</xmlelement> elements.</p>
       <p>The <xmlelement>mathml</xmlelement> element is not intended to represent a semantic
         equation, only content that contributes to a semantic equation. Use the equation domain
         elements or their equivalent to represent equations semantically, for example, to enable

--- a/specification/langRef/technicalContent/svg-container.dita
+++ b/specification/langRef/technicalContent/svg-container.dita
@@ -16,8 +16,8 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p><xmlelement>svg-container</xmlelement> content includes SVG elements, references to SVG
-        elements that are stored in separate, non-DITA documents, <xmlelement>data</xmlelement>, or
-          <xmlelement>data-about</xmlelement> elements.</p>
+        elements that are stored in separate, non-DITA documents, or <xmlelement>data</xmlelement>
+          elements.</p>
       <p>The SVG markup must have a root element of <xmlelement>svg</xmlelement> with the SVG
         namespace: "http://www.w3.org/2000/svg".</p>
     </section>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -224,14 +224,6 @@
           <stentry/>
         </strow>
         <strow>
-          <stentry><xmlelement>data-about</xmlelement></stentry>
-          <stentry>N/A</stentry>
-          <stentry>N/A (metadata)</stentry>
-          <stentry>block</stentry>
-          <stentry>no</stentry>
-          <stentry/>
-        </strow>
-        <strow>
           <stentry><xmlelement>dd</xmlelement></stentry>
           <stentry>N/A</stentry>
           <stentry>block</stentry>


### PR DESCRIPTION
This includes the changes that will be required in the tech comm content for removing the `data-about` element.