### PR TITLE
Change base of itemgroup to div oasis-tcs/dita#397

### DIFF
--- a/doctypes/dtd/technicalContent/task.mod
+++ b/doctypes/dtd/technicalContent/task.mod
@@ -229,7 +229,7 @@
                          (%choices; |
                           %choicetable; |
                           %info; |
-                          %itemgroup; |
+                          %div; |
                           %stepxmp; |
                           %steps; |
                           %steps-unordered; |
@@ -265,7 +265,7 @@
 
 <!--                    LONG NAME: Information                     -->
 <!ENTITY % info.content
-                       "(%itemgroup.cnt;)*"
+                       "(%div.cnt;)*"
 >
 <!ENTITY % info.attributes
               "%univ-atts;"
@@ -276,7 +276,7 @@
 
 <!--                    LONG NAME: Tutorial Information            -->
 <!ENTITY % tutorialinfo.content
-                       "(%itemgroup.cnt;)*"
+                       "(%div.cnt;)*"
 >
 <!ENTITY % tutorialinfo.attributes
               "%univ-atts;"
@@ -285,7 +285,7 @@
 <!ATTLIST  tutorialinfo %tutorialinfo.attributes;>
 
 
-<!-- Match itemgroup.cnt from base, but exclude example element    -->
+<!-- Match div.cnt from base, but exclude example element    -->
 <!ENTITY % stepxmp.cnt
               "#PCDATA |
                %basic.block.noexample; |
@@ -476,7 +476,7 @@
 
 <!--                    LONG NAME: Step Result                     -->
 <!ENTITY % stepresult.content
-                       "(%itemgroup.cnt;)*"
+                       "(%div.cnt;)*"
 >
 <!ENTITY % stepresult.attributes
               "%univ-atts;"
@@ -487,7 +487,7 @@
 
 <!--                    LONG NAME: Step Troubleshooting            -->
 <!ENTITY % steptroubleshooting.content
-                       "(%itemgroup.cnt;)*"
+                       "(%div.cnt;)*"
 >
 <!ENTITY % steptroubleshooting.attributes
               "%univ-atts;"
@@ -541,11 +541,11 @@
 <!ATTLIST  stepsection  class CDATA "- topic/li task/stepsection ">
 <!ATTLIST  step         class CDATA "- topic/li task/step ">
 <!ATTLIST  cmd          class CDATA "- topic/ph task/cmd ">
-<!ATTLIST  tutorialinfo class CDATA "- topic/itemgroup task/tutorialinfo ">
-<!ATTLIST  info         class CDATA "- topic/itemgroup task/info ">
-<!ATTLIST  stepxmp      class CDATA "- topic/itemgroup task/stepxmp ">
-<!ATTLIST  stepresult   class CDATA "- topic/itemgroup task/stepresult ">
-<!ATTLIST  steptroubleshooting class CDATA "- topic/itemgroup task/steptroubleshooting ">
+<!ATTLIST  tutorialinfo class CDATA "- topic/div task/tutorialinfo ">
+<!ATTLIST  info         class CDATA "- topic/div task/info ">
+<!ATTLIST  stepxmp      class CDATA "- topic/div task/stepxmp ">
+<!ATTLIST  stepresult   class CDATA "- topic/div task/stepresult ">
+<!ATTLIST  steptroubleshooting class CDATA "- topic/div task/steptroubleshooting ">
 <!ATTLIST  choices      class CDATA "- topic/ul task/choices ">
 <!ATTLIST  choice       class CDATA "- topic/li task/choice ">
 <!ATTLIST  result       class CDATA "- topic/section task/result ">

--- a/doctypes/rng/technicalContent/taskMod.rng
+++ b/doctypes/rng/technicalContent/taskMod.rng
@@ -173,7 +173,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
   
   <div>
     <a:documentation>COMMON CONTENT MODEL PATTERNS</a:documentation>
-    <!-- Match itemgroup.cnt but exclude example -->
+    <!-- Match div.cnt but exclude example -->
     <define name="stepxmp.cnt">
       <choice>
         <text/>
@@ -478,7 +478,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
             <ref name="choices"/>
             <ref name="choicetable"/>
             <ref name="info"/>
-            <ref name="itemgroup"/>
+            <ref name="div"/>
             <ref name="stepxmp"/>
             <ref name="steps"/>
             <ref name="steps-unordered"/>
@@ -551,7 +551,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
       <a:documentation> LONG NAME: Information </a:documentation>
       <define name="info.content">
         <zeroOrMore>
-          <ref name="itemgroup.cnt"/>
+          <ref name="div.cnt"/>
         </zeroOrMore>
       </define>
       <define name="info.attributes">
@@ -575,7 +575,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
       <a:documentation> LONG NAME: Tutorial Information </a:documentation>
       <define name="tutorialinfo.content">
         <zeroOrMore>
-          <ref name="itemgroup.cnt"/>
+          <ref name="div.cnt"/>
         </zeroOrMore>
       </define>
       <define name="tutorialinfo.attributes">
@@ -881,7 +881,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
       <a:documentation> LONG NAME: Step Result </a:documentation>
       <define name="stepresult.content">
         <zeroOrMore>
-          <ref name="itemgroup.cnt"/>
+          <ref name="div.cnt"/>
         </zeroOrMore>
       </define>
       <define name="stepresult.attributes">
@@ -906,7 +906,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
       <a:documentation> LONG NAME: Step Troubleshooting </a:documentation>
       <define name="steptroubleshooting.content">
         <zeroOrMore>
-          <ref name="itemgroup.cnt"/>
+          <ref name="div.cnt"/>
         </zeroOrMore>
       </define>
       <define name="steptroubleshooting.attributes">
@@ -1042,27 +1042,27 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
     </define>
     <define name="tutorialinfo.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="- topic/itemgroup task/tutorialinfo "/>
+        <attribute name="class" a:defaultValue="- topic/div task/tutorialinfo "/>
       </optional>
     </define>
     <define name="info.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="- topic/itemgroup task/info "/>
+        <attribute name="class" a:defaultValue="- topic/div task/info "/>
       </optional>
     </define>
     <define name="stepxmp.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="- topic/itemgroup task/stepxmp "/>
+        <attribute name="class" a:defaultValue="- topic/div task/stepxmp "/>
       </optional>
     </define>
     <define name="stepresult.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="- topic/itemgroup task/stepresult "/>
+        <attribute name="class" a:defaultValue="- topic/div task/stepresult "/>
       </optional>
     </define>
     <define name="steptroubleshooting.attlist" combine="interleave">
       <optional>
-        <attribute name="class" a:defaultValue="- topic/itemgroup task/steptroubleshooting "/>
+        <attribute name="class" a:defaultValue="- topic/div task/steptroubleshooting "/>
       </optional>
     </define>
     <define name="choices.attlist" combine="interleave">

--- a/specification/langRef/technicalContent/info.dita
+++ b/specification/langRef/technicalContent/info.dita
@@ -11,7 +11,7 @@
       <section id="specialization-hierarchy">
          <title>Specialization hierarchy</title>
          <p>The <xmlelement>info</xmlelement> element is specialized from
-                              <xmlelement>itemgroup</xmlelement>. It is defined in the task
+                              <xmlelement>div</xmlelement>. It is defined in the task
                         module.</p>
       </section>
       <section id="attributes">

--- a/specification/langRef/technicalContent/steptroubleshooting.dita
+++ b/specification/langRef/technicalContent/steptroubleshooting.dita
@@ -24,7 +24,7 @@
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>steptroubleshooting</xmlelement> element is specialized from
-          <xmlelement>itemgroup</xmlelement>. It is defined in the task module.</p>
+          <xmlelement>div</xmlelement>. It is defined in the task module.</p>
 </section>
     <section id="attributes">
       <title>Attributes</title>

--- a/specification/langRef/technicalContent/stepxmp.dita
+++ b/specification/langRef/technicalContent/stepxmp.dita
@@ -12,7 +12,7 @@
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>stepxmp</xmlelement> element is specialized from
-     <xmlelement>itemgroup</xmlelement>. It is defined in the task module.</p>
+     <xmlelement>div</xmlelement>. It is defined in the task module.</p>
 </section>
 <section id="attributes"><title>Attributes</title>
 <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>

--- a/specification/langRef/technicalContent/tutorialinfo.dita
+++ b/specification/langRef/technicalContent/tutorialinfo.dita
@@ -12,7 +12,7 @@
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>tutorialinfo</xmlelement> element is specialized from
-          <xmlelement>itemgroup</xmlelement>. It is defined in the task module.</p>
+          <xmlelement>div</xmlelement>. It is defined in the task module.</p>
 </section>
 <section id="attributes"><title>Attributes</title>
    <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -412,14 +412,6 @@
           <stentry/>
         </strow>
         <strow>
-          <stentry><xmlelement>itemgroup</xmlelement></stentry>
-          <stentry>N/A</stentry>
-          <stentry>inline</stentry>
-          <stentry>inline</stentry>
-          <stentry>yes</stentry>
-          <stentry/>
-        </strow>
-        <strow>
           <stentry><xmlelement>keyword</xmlelement></stentry>
           <stentry>N/A</stentry>
           <stentry>inline</stentry>
@@ -2056,7 +2048,7 @@
         </strow>
         <strow>
           <stentry><xmlelement>info</xmlelement></stentry>
-          <stentry><xmlelement>itemgroup</xmlelement></stentry>
+          <stentry><xmlelement>div</xmlelement></stentry>
           <stentry><b>NO</b></stentry>
           <stentry>inline</stentry>
           <stentry><b>block</b></stentry>
@@ -2101,7 +2093,7 @@
         </strow>
         <strow>
           <stentry><xmlelement>stepresult</xmlelement></stentry>
-          <stentry><xmlelement>itemgroup</xmlelement></stentry>
+          <stentry><xmlelement>div</xmlelement></stentry>
           <stentry><b>NO</b></stentry>
           <stentry>inline</stentry>
           <stentry><b>block</b></stentry>
@@ -2146,7 +2138,7 @@
         </strow>
         <strow>
           <stentry><xmlelement>steptroubleshooting</xmlelement></stentry>
-          <stentry><xmlelement>itemgroup</xmlelement></stentry>
+          <stentry><xmlelement>div</xmlelement></stentry>
           <stentry>yes</stentry>
           <stentry>block</stentry>
           <stentry>block</stentry>
@@ -2155,7 +2147,7 @@
         </strow>
         <strow>
           <stentry><xmlelement>stepxmp</xmlelement></stentry>
-          <stentry><xmlelement>itemgroup</xmlelement></stentry>
+          <stentry><xmlelement>div</xmlelement></stentry>
           <stentry><b>NO</b></stentry>
           <stentry>inline</stentry>
           <stentry><b>block</b></stentry>
@@ -2191,7 +2183,7 @@
         </strow>
         <strow>
           <stentry><xmlelement>tutorialinfo</xmlelement></stentry>
-          <stentry><xmlelement>itemgroup</xmlelement></stentry>
+          <stentry><xmlelement>div</xmlelement></stentry>
           <stentry><b>NO</b></stentry>
           <stentry>inline</stentry>
           <stentry><b>block</b></stentry>


### PR DESCRIPTION
* Updates specialization base of all itemgroup elements to come from div
* Updates spec topics to match
* In `step` element, which allowed `itemgroup`, allow the replacement `div`