### PR TITLE
Integrate strong/em elements into tech comm shells

### DIFF
--- a/doctypes/dtd/bookmap/bookmap.dtd
+++ b/doctypes/dtd/bookmap/bookmap.dtd
@@ -65,6 +65,11 @@
          "../technicalContent/abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % hazard-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Hazard Statement Domain//EN"
          "../base/hazardstatementDomain.ent"
@@ -169,6 +174,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -274,6 +280,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "../technicalContent/abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % hazard-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Hazard Statement Domain//EN"

--- a/doctypes/dtd/classificationMap/classifyMap.dtd
+++ b/doctypes/dtd/classificationMap/classifyMap.dtd
@@ -61,6 +61,11 @@
          "../base/ditavalrefDomain.ent"
 >%ditavalref-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % glossref-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Glossary Reference Domain//EN"
          "../technicalContent/glossrefDomain.ent"
@@ -162,6 +167,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %pr-d-ph; |
                          %sw-d-ph; |
@@ -265,6 +271,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
          "../base/ditavalrefDomain.mod"
 >%ditavalref-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % glossref-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Reference Domain//EN"

--- a/doctypes/dtd/technicalContent/concept.dtd
+++ b/doctypes/dtd/technicalContent/concept.dtd
@@ -48,6 +48,11 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -158,6 +163,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -265,6 +271,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/ditabase.dtd
@@ -49,6 +49,11 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -159,6 +164,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -317,6 +323,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/generalTask.dtd
+++ b/doctypes/dtd/technicalContent/generalTask.dtd
@@ -49,6 +49,11 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -159,6 +164,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -266,6 +272,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/glossentry.dtd
+++ b/doctypes/dtd/technicalContent/glossentry.dtd
@@ -42,6 +42,11 @@
 <!--             DOMAIN ENTITY DECLARATIONS                        -->
 <!-- ============================================================= -->
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -157,6 +162,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -264,6 +270,11 @@
 <!-- ============================================================= -->
 <!--                    DOMAIN ELEMENT INTEGRATION                 -->
 <!-- ============================================================= -->
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/glossgroup.dtd
+++ b/doctypes/dtd/technicalContent/glossgroup.dtd
@@ -39,6 +39,11 @@
 <!--             DOMAIN ENTITY DECLARATIONS                        -->
 <!-- ============================================================= -->
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -154,6 +159,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -272,6 +278,11 @@
 <!-- ============================================================= -->
 <!--                    DOMAIN ELEMENT INTEGRATION                 -->
 <!-- ============================================================= -->
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/map.dtd
+++ b/doctypes/dtd/technicalContent/map.dtd
@@ -68,6 +68,11 @@
          "glossrefDomain.ent"
 >%glossref-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % hazard-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Hazard Statement Domain//EN"
          "../base/hazardstatementDomain.ent"
@@ -168,6 +173,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -265,6 +271,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 DITAVAL Ref Domain//EN"
          "../base/ditavalrefDomain.mod"
 >%ditavalref-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % glossref-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Reference Domain//EN"

--- a/doctypes/dtd/technicalContent/reference.dtd
+++ b/doctypes/dtd/technicalContent/reference.dtd
@@ -50,6 +50,11 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -160,6 +165,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -267,6 +273,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/task.dtd
+++ b/doctypes/dtd/technicalContent/task.dtd
@@ -48,6 +48,11 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -158,6 +163,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -270,6 +276,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/topic.dtd
+++ b/doctypes/dtd/technicalContent/topic.dtd
@@ -47,6 +47,11 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -157,6 +162,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -259,6 +265,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/dtd/technicalContent/troubleshooting.dtd
+++ b/doctypes/dtd/technicalContent/troubleshooting.dtd
@@ -47,6 +47,11 @@
          "abbreviateDomain.ent"
 >%abbrev-d-dec;
 
+<!ENTITY % emphasis-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.ent"
+>%emphasis-d-dec;
+
 <!ENTITY % equation-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 Equation Domain//EN"
          "equationDomain.ent"
@@ -157,6 +162,7 @@
                          %hazard-d-note;
                         ">
 <!ENTITY % ph           "ph |
+                         %emphasis-d-ph; |
                          %hi-d-ph; |
                          %hw-d-ph; |
                          %pr-d-ph; |
@@ -277,6 +283,11 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
          "abbreviateDomain.mod"
 >%abbrev-d-def;
+
+<!ENTITY % emphasis-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Emphasis Domain//EN"
+         "../base/emphasisDomain.mod"
+>%emphasis-d-def;
 
 <!ENTITY % equation-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Equation Domain//EN"

--- a/doctypes/rng/bookmap/bookmap.rng
+++ b/doctypes/rng/bookmap/bookmap.rng
@@ -90,6 +90,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 BookMap//EN"
      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
+     <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
      <include href="../technicalContent/hwDomain.rng" dita:since="2.0"/>

--- a/doctypes/rng/bookmap/bookmap.rng
+++ b/doctypes/rng/bookmap/bookmap.rng
@@ -51,12 +51,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 BookMap//EN"
          <moduleShortName>bookmap</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> BookMap//EN</dtdShell>
-            <rncShell>urn:oasis:names:tc:dita:rnc:bookmap.rnc<var presep=":" name="ditaver"/>
-            </rncShell>
-            <rngShell>urn:oasis:names:tc:dita:rng:bookmap.rng<var presep=":" name="ditaver"/>
-            </rngShell>
-            <xsdShell>urn:oasis:names:tc:dita:xsd:bookmap.xsd<var presep=":" name="ditaver"/>
-            </xsdShell>
+            <rngShell>urn:oasis:names:tc:dita:rng:bookmap.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/bookmap/bookmapMod.rng
+++ b/doctypes/rng/bookmap/bookmapMod.rng
@@ -41,9 +41,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> BookMap//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> BookMap//EN</dtdEnt>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:bookmapGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:bookmapMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:bookmapMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:bookmapMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/classificationMap/classifyMap.rng
+++ b/doctypes/rng/classificationMap/classifyMap.rng
@@ -75,20 +75,21 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Classification Map//EN"
   </div>
   <div>
       <a:documentation>MODULE INCLUSIONS</a:documentation>
-     <include href="urn:oasis:names:tc:dita:rng:mapMod.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:mapMod.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
   
-     <include href="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"/>
       <include href="../technicalContent/abbreviateDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
-     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
       <include href="../technicalContent/glossrefDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>
       <include href="../technicalContent/markupDomain.rng" dita:since="1.3"/>
       <include href="../technicalContent/programmingDomain.rng"/>
       <include href="../technicalContent/releaseManagementDomain.rng"
@@ -96,7 +97,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Classification Map//EN"
       <include href="../technicalContent/softwareDomain.rng"/>
       <include href="../technicalContent/syntaxdiagramDomain.rng" dita:since="2.0"/>
       <include href="../technicalContent/uiDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:utilitiesDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:utilitiesDomain.rng:2.0"/>
       <include href="../technicalContent/xmlDomain.rng" dita:since="1.3"/>    </div>
   <div>
       <a:documentation>ID-DEFINING-ELEMENT OVERRIDES</a:documentation>

--- a/doctypes/rng/classificationMap/classifyMap.rng
+++ b/doctypes/rng/classificationMap/classifyMap.rng
@@ -48,12 +48,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Classification Map//EN"
          <moduleShortName>classifyMap</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Classification Map//EN</dtdShell>
-            <rncShell>urn:oasis:tc:tc:dita:spec:classification:rnc:classifyMap.rnc<var presep=":" name="ditaver"/>
-            </rncShell>
-            <rngShell>urn:oasis:tc:tc:dita:spec:classification:rng:classifyMap.rng<var presep=":" name="ditaver"/>
-            </rngShell>
-            <xsdShell>urn:oasis:tc:tc:dita:spec:classification:xsd:classifyMap.xsd<var presep=":" name="ditaver"/>
-            </xsdShell>
+            <rngShell>urn:oasis:tc:tc:dita:spec:classification:rng:classifyMap.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/abbreviateDomain.rng
+++ b/doctypes/rng/technicalContent/abbreviateDomain.rng
@@ -38,8 +38,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Abbreviated Form Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Abbreviated Form Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Abbreviated Form Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:abbreviateDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:abbreviateDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:abbreviateDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/concept.rng
+++ b/doctypes/rng/technicalContent/concept.rng
@@ -90,6 +90,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Concept//EN"
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/concept.rng
+++ b/doctypes/rng/technicalContent/concept.rng
@@ -50,9 +50,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Concept//EN"
       <moduleShortName>concept</moduleShortName>
       <shellPublicIds>
         <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Concept//EN</dtdShell>
-        <rncShell>urn:oasis:names:tc:dita:rnc:concept.rnc<var presep=":" name="ditaver"/></rncShell>
         <rngShell>urn:oasis:names:tc:dita:rng:concept.rng<var presep=":" name="ditaver"/></rngShell>
-        <xsdShell>urn:oasis:names:tc:dita:xsd:concept.xsd<var presep=":" name="ditaver"/></xsdShell>
       </shellPublicIds>
     </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/conceptMod.rng
+++ b/doctypes/rng/technicalContent/conceptMod.rng
@@ -39,9 +39,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Concept//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Concept//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Concept//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:conceptMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:conceptGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:conceptMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:conceptMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/ditabase.rng
+++ b/doctypes/rng/technicalContent/ditabase.rng
@@ -53,9 +53,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Composite//EN"
          <moduleShortName>ditabase</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Composite//EN</dtdShell>
-            <rncShell>urn:oasis:names:tc:dita:rnc:ditabase.rnc<var presep=":" name="ditaver"/></rncShell>
             <rngShell>urn:oasis:names:tc:dita:rng:ditabase.rng<var presep=":" name="ditaver"/></rngShell>
-            <xsdShell>urn:oasis:names:tc:dita:xsd:ditabase.xsd<var presep=":" name="ditaver"/></xsdShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/ditabase.rng
+++ b/doctypes/rng/technicalContent/ditabase.rng
@@ -102,11 +102,12 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Composite//EN"
       <include href="troubleshootingMod.rng"/>
     
       <include href="abbreviateDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
-     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/equationDomain.rng
+++ b/doctypes/rng/technicalContent/equationDomain.rng
@@ -26,8 +26,6 @@ Copyright (c) OASIS Open 2014
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Equation Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Equation Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:equationDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:equationDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:equationDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/generalTask.rng
+++ b/doctypes/rng/technicalContent/generalTask.rng
@@ -90,6 +90,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 General Task//EN"
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/generalTask.rng
+++ b/doctypes/rng/technicalContent/generalTask.rng
@@ -50,9 +50,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 General Task//EN"
       <moduleShortName>General Task</moduleShortName>
       <shellPublicIds>
         <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> General Task//EN</dtdShell>
-        <rncShell>urn:oasis:names:tc:dita:rnc:generalTask.rnc<var presep=":" name="ditaver"/></rncShell>
         <rngShell>urn:oasis:names:tc:dita:rng:generalTask.rng<var presep=":" name="ditaver"/></rngShell>
-        <xsdShell>urn:oasis:names:tc:dita:xsd:generalTask.xsd<var presep=":" name="ditaver"/></xsdShell>
       </shellPublicIds>
     </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/glossentry.rng
+++ b/doctypes/rng/technicalContent/glossentry.rng
@@ -52,12 +52,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Glossary Entry//EN"
          <moduleShortName>Glossary Entry</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Glossary Entry//EN</dtdShell>
-            <rncShell>urn:oasis:names:tc:dita:rnc:glossentry.rnc<var presep=":" name="ditaver"/>
-            </rncShell>
-            <rngShell>urn:oasis:names:tc:dita:rng:glossentry.rng<var presep=":" name="ditaver"/>
-            </rngShell>
-            <xsdShell>urn:oasis:names:tc:dita:xsd:glossentry.xsd<var presep=":" name="ditaver"/>
-            </xsdShell>
+            <rngShell>urn:oasis:names:tc:dita:rng:glossentry.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/glossentry.rng
+++ b/doctypes/rng/technicalContent/glossentry.rng
@@ -84,11 +84,12 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Glossary Entry//EN"
           <empty/>
         </define>
       </include>
-     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
-     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/glossentryMod.rng
+++ b/doctypes/rng/technicalContent/glossentryMod.rng
@@ -43,9 +43,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Entry//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Glossary Entry//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Glossary Entry//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:glossentryMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:glossentryGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:glossentryMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:glossentryMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/glossgroup.rng
+++ b/doctypes/rng/technicalContent/glossgroup.rng
@@ -45,8 +45,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.x Glossary Group//EN"
       <moduleShortName>glossgroup</moduleShortName>
       <shellPublicIds>
         <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Glossary Group//EN</dtdShell>
-        <xsdShell>urn:oasis:names:tc:dita:xsd:glossgroup.xsd<var presep=":" name="ditaver"/></xsdShell>
-        <rncShell>urn:oasis:names:tc:dita:rnc:glossgroup.rnc<var presep=":" name="ditaver"/></rncShell>
         <rngShell>urn:oasis:names:tc:dita:rng:glossgroup.rng<var presep=":" name="ditaver"/></rngShell>
       </shellPublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/glossgroup.rng
+++ b/doctypes/rng/technicalContent/glossgroup.rng
@@ -82,6 +82,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.x Glossary Group//EN"
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/glossgroupMod.rng
+++ b/doctypes/rng/technicalContent/glossgroupMod.rng
@@ -39,9 +39,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Group//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Glossary Group//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Glossary Group//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:glossgroupMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:glossgroupGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:glossgroupMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:glossgroupMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/glossrefDomain.rng
+++ b/doctypes/rng/technicalContent/glossrefDomain.rng
@@ -38,8 +38,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Reference Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Glossary Reference Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Glossary Reference Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:glossrefDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:glossrefDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:glossrefDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/map.rng
+++ b/doctypes/rng/technicalContent/map.rng
@@ -80,16 +80,17 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Map//EN"
   </div>
   <div>
       <a:documentation>MODULE INCLUSIONS</a:documentation>
-     <include href="urn:oasis:names:tc:dita:rng:mapMod.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:mapMod.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
 
       <include href="abbreviateDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
-     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:ditavalrefDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
       <include href="glossrefDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/map.rng
+++ b/doctypes/rng/technicalContent/map.rng
@@ -53,12 +53,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Map//EN"
          <moduleShortName>map</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Map//EN</dtdShell>
-            <rncShell>urn:oasis:names:tc:dita:rnc:map.rnc<var presep=":" name="ditaver"/>
-            </rncShell>
-            <rngShell>urn:oasis:names:tc:dita:rng:map.rng<var presep=":" name="ditaver"/>
-            </rngShell>
-            <xsdShell>urn:oasis:names:tc:dita:xsd:map.xsd<var presep=":" name="ditaver"/>
-            </xsdShell>
+            <rngShell>urn:oasis:names:tc:dita:rng:map.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/markupDomain.rng
+++ b/doctypes/rng/technicalContent/markupDomain.rng
@@ -24,8 +24,6 @@
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Markup Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Markup Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:markupDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:markupDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:markupDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/mathmlDomain.rng
+++ b/doctypes/rng/technicalContent/mathmlDomain.rng
@@ -42,8 +42,6 @@ All Rights Reserved.
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> MathML Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> MathML Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:mathmlDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:mathmlDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:mathmlDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/programmingDomain.rng
+++ b/doctypes/rng/technicalContent/programmingDomain.rng
@@ -39,8 +39,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Programming Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Programming Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Programming Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:programmingDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:programmingDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:programmingDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/reference.rng
+++ b/doctypes/rng/technicalContent/reference.rng
@@ -51,9 +51,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Reference//EN"
       <moduleShortName>reference</moduleShortName>
       <shellPublicIds>
         <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Reference//EN</dtdShell>
-        <rncShell>urn:oasis:names:tc:dita:rnc:reference.rnc<var presep=":" name="ditaver"/></rncShell>
         <rngShell>urn:oasis:names:tc:dita:rng:reference.rng<var presep=":" name="ditaver"/></rngShell>
-        <xsdShell>urn:oasis:names:tc:dita:xsd:reference.xsd<var presep=":" name="ditaver"/></xsdShell>
       </shellPublicIds>
     </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/reference.rng
+++ b/doctypes/rng/technicalContent/reference.rng
@@ -90,6 +90,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Reference//EN"
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/referenceMod.rng
+++ b/doctypes/rng/technicalContent/referenceMod.rng
@@ -40,9 +40,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Reference//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Reference//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Reference//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:referenceMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:referenceGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <rncMod>urn:oasis:names:tc:dita:rnc:referenceMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:referenceMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/releaseManagementDomain.rng
+++ b/doctypes/rng/technicalContent/releaseManagementDomain.rng
@@ -33,8 +33,6 @@ PUBLIC "-//OASIS//ENTITIES DITA 2.0 Release Management Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Release Management Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Release Management Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:releaseManagementDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:releaseManagementDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:releaseManagementDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/softwareDomain.rng
+++ b/doctypes/rng/technicalContent/softwareDomain.rng
@@ -40,8 +40,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Software Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Software Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Software Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:softwareDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:softwareDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:softwareDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/strictTaskbodyConstraintMod.rng
+++ b/doctypes/rng/technicalContent/strictTaskbodyConstraintMod.rng
@@ -37,8 +37,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Strict Taskbody Constraint//EN"
       <moduleShortName>strictTaskbody</moduleShortName>
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Strict Taskbody Constraint//EN</dtdMod>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:strictTaskbodyConstraintMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:strictTaskbodyConstraintMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:strictTaskbodyConstraintMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/svgDomain.rng
+++ b/doctypes/rng/technicalContent/svgDomain.rng
@@ -18,8 +18,6 @@ DITA SVG Domain
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> SVG Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> SVG Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:svgDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:svgDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:svgDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/syntaxdiagramDomain.rng
+++ b/doctypes/rng/technicalContent/syntaxdiagramDomain.rng
@@ -39,8 +39,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Syntax Diagram Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Syntax Diagram Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Syntax Diagram Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:syntaxdiagramDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:syntaxdiagramDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:syntaxdiagramDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/task.rng
+++ b/doctypes/rng/technicalContent/task.rng
@@ -52,8 +52,6 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Task//EN"
          <moduleShortName>task</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Task//EN</dtdShell>
-            <xsdShell>urn:oasis:names:tc:dita:xsd:task.xsd<var presep=":" name="ditaver"/></xsdShell>
-            <rncShell>urn:oasis:names:tc:dita:rnc:task.rnc<var presep=":" name="ditaver"/></rncShell>
             <rngShell>urn:oasis:names:tc:dita:rng:task.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>

--- a/doctypes/rng/technicalContent/task.rng
+++ b/doctypes/rng/technicalContent/task.rng
@@ -91,11 +91,12 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Task//EN"
       <a:documentation> MODULE INCLUSIONS </a:documentation>
       <include href="urn:oasis:names:tc:dita:rng:topicMod.rng:2.0"/>
       <include href="abbreviateDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
-     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
       <include href="equationDomain.rng" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/taskMod.rng
+++ b/doctypes/rng/technicalContent/taskMod.rng
@@ -40,9 +40,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Task//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Task//EN</dtdEnt>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:taskGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:taskMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:taskMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:taskMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/topic.rng
+++ b/doctypes/rng/technicalContent/topic.rng
@@ -51,9 +51,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Topic//EN"
       <moduleShortName>topic</moduleShortName>
       <shellPublicIds>
         <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Topic//EN</dtdShell>
-        <rncShell>urn:oasis:names:tc:dita:rnc:topic.rnc<var presep=":" name="ditaver"/></rncShell>
         <rngShell>urn:oasis:names:tc:dita:rng:topic.rng<var presep=":" name="ditaver"/></rngShell>
-        <xsdShell>urn:oasis:names:tc:dita:xsd:topic.xsd<var presep=":" name="ditaver"/></xsdShell>
       </shellPublicIds>
     </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/topic.rng
+++ b/doctypes/rng/technicalContent/topic.rng
@@ -89,6 +89,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Topic//EN"
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
     <include href="equationDomain.rng" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/troubleshooting.rng
@@ -90,11 +90,12 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Troubleshooting//EN"
          </define>
       </include>
       <include href="abbreviateDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
-     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
-     <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
+      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:productAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:otherpropsAttDomain.rng:2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:emphasisDomain.rng:2.0"/>
       <include href="equationDomain.rng"/>
       <include href="urn:oasis:names:tc:dita:rng:hazardDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:highlightDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/troubleshooting.rng
@@ -50,12 +50,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Troubleshooting//EN"
          <moduleShortName>troubleshooting</moduleShortName>
          <shellPublicIds>
             <dtdShell>-//OASIS//DTD DITA<var presep=" " name="ditaver"/> Troubleshooting//EN</dtdShell>
-            <xsdShell>urn:oasis:names:tc:dita:xsd:troubleshooting.xsd<var presep=":" name="ditaver"/>
-            </xsdShell>
-            <rncShell>urn:oasis:names:tc:dita:rnc:troubleshooting.rnc<var presep=":" name="ditaver"/>
-            </rncShell>
-            <rngShell>urn:oasis:names:tc:dita:rng:troubleshooting.rng<var presep=":" name="ditaver"/>
-            </rngShell>
+            <rngShell>urn:oasis:names:tc:dita:rng:troubleshooting.rng<var presep=":" name="ditaver"/></rngShell>
          </shellPublicIds>
       </moduleMetadata>
   </moduleDesc>

--- a/doctypes/rng/technicalContent/troubleshootingMod.rng
+++ b/doctypes/rng/technicalContent/troubleshootingMod.rng
@@ -37,9 +37,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Troubleshooting//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> Troubleshooting//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> Troubleshooting//EN</dtdEnt>
-        <xsdGrp>urn:oasis:names:tc:dita:xsd:troubleshootingGrp.xsd<var presep=":" name="ditaver"/></xsdGrp>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:troubleshootingMod.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:troubleshootingMod.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:troubleshootingMod.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/uiDomain.rng
+++ b/doctypes/rng/technicalContent/uiDomain.rng
@@ -39,8 +39,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 User Interface Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> User Interface Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> User Interface Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:uiDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:uiDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:uiDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/technicalContent/xmlDomain.rng
+++ b/doctypes/rng/technicalContent/xmlDomain.rng
@@ -24,8 +24,6 @@
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> XML Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> XML Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:xmlDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:xmlDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:xmlDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>

--- a/doctypes/rng/xnal/xnalDomain.rng
+++ b/doctypes/rng/xnal/xnalDomain.rng
@@ -37,8 +37,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 XNAL Domain//EN"
       <modulePublicIds>
         <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> XNAL Domain//EN</dtdMod>
         <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> XNAL Domain//EN</dtdEnt>
-        <xsdMod>urn:oasis:names:tc:dita:xsd:xnalDomain.xsd<var presep=":" name="ditaver"/></xsdMod>
-        <rncMod>urn:oasis:names:tc:dita:rnc:xnalDomain.rnc<var presep=":" name="ditaver"/></rncMod>
         <rngMod>urn:oasis:names:tc:dita:rng:xnalDomain.rng<var presep=":" name="ditaver"/></rngMod>
       </modulePublicIds>
     </moduleMetadata>


### PR DESCRIPTION
Implements oasis-tcs/dita#107 within the tech comm shells:
* Do some grammar cleanup while in the RNG (matching oasis-tcs/dita#400 clean out obsolete doc)
* Update to latest base spec, to make emphasis domain available
* Update shells to use the emphasis domain