### PR TITLE
Fix key refs for diagnostics

### DIFF
--- a/specification/langRef/quick-reference/technicalContent-elements-a-to-z.dita
+++ b/specification/langRef/quick-reference/technicalContent-elements-a-to-z.dita
@@ -79,6 +79,9 @@
         <sli><xref keyref="elements-day"/></sli>
         <sli><xref keyref="elements-dedication"/></sli>
         <sli><xref keyref="elements-delim"/></sli>
+        <sli><xref keyref="elements-diagnostics"/></sli>
+        <sli><xref keyref="elements-diagnostics-general"/></sli>
+        <sli><xref keyref="elements-diagnostics-steps"/></sli>
         <sli><xref keyref="elements-draftintro"/></sli>
         <sli><xref keyref="elements-edited"/></sli>
         <sli><xref keyref="elements-edition"/></sli>

--- a/specification/langRef/technicalContent/diagnostics.dita
+++ b/specification/langRef/technicalContent/diagnostics.dita
@@ -33,8 +33,8 @@
         </section>
         <example id="example" otherprops="examples">
             <title>Example</title>
-            <p>See <xref keyref="diagnostics-general"/> and <xref
-                keyref="diagnostics-steps"/>.</p>
+            <p>See <xref keyref="elements-diagnostics-general"/> and <xref
+                keyref="elements-diagnostics-steps"/>.</p>
         </example>
     </refbody>
 </reference>


### PR DESCRIPTION
Two key references left off part of the key name; also adding the three elements into the A-to-Z topic.