### PR TITLE
Add idElements as noted in dita-ot/dita-ot#3181

### DIFF
--- a/doctypes/rng/technicalContent/glossentryMod.rng
+++ b/doctypes/rng/technicalContent/glossentryMod.rng
@@ -154,6 +154,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Entry//EN"
         <ref name="arch-atts"/>
         <ref name="specializations-att"/>
       </define>
+      <define name="idElements" combine="choice">
+        <ref name="glossentry.element"/>
+      </define>
     </div>
     <div>
       <a:documentation> LONG NAME: Glossary Term </a:documentation>

--- a/doctypes/rng/technicalContent/glossgroupMod.rng
+++ b/doctypes/rng/technicalContent/glossgroupMod.rng
@@ -96,6 +96,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Group//EN"
         <ref name="arch-atts"/>
         <ref name="specializations-att"/>
       </define>
+      <define name="idElements" combine="choice">
+        <ref name="glossgroup.element"/>
+      </define>
     </div>
   </div>
   <div>

--- a/doctypes/rng/technicalContent/referenceMod.rng
+++ b/doctypes/rng/technicalContent/referenceMod.rng
@@ -146,6 +146,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Reference//EN"
         <ref name="arch-atts"/>
         <ref name="specializations-att"/>
       </define>
+      <define name="idElements" combine="choice">
+        <ref name="reference.element"/>
+      </define>
 
     </div>
     <div>

--- a/doctypes/rng/technicalContent/taskMod.rng
+++ b/doctypes/rng/technicalContent/taskMod.rng
@@ -237,7 +237,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
         <ref name="arch-atts"/>
         <ref name="specializations-att"/>
       </define>
-
+      <define name="idElements" combine="choice">
+        <ref name="task.element"/>
+      </define>
     </div>
     <div>
       <a:documentation> LONG NAME: Task Body </a:documentation>

--- a/doctypes/rng/technicalContent/troubleshootingMod.rng
+++ b/doctypes/rng/technicalContent/troubleshootingMod.rng
@@ -151,6 +151,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Troubleshooting//EN"
         <ref name="arch-atts"/>
         <ref name="specializations-att"/>
       </define>
+      <define name="idElements" combine="choice">
+        <ref name="troubleshooting.element"/>
+      </define>
     </div>
     <div>
       <a:documentation> LONG NAME: Troubleshooting Body </a:documentation>


### PR DESCRIPTION
Add `idElements` definition to mod files noted in dita-ot/dita-ot#3181 (and to other mod files that are also missing the definition).

@drmacro does this look like a good change for consistency?