### PR TITLE
Add scope att to svgref

### DIFF
--- a/doctypes/dtd/technicalContent/svgDomain.mod
+++ b/doctypes/dtd/technicalContent/svgDomain.mod
@@ -49,6 +49,12 @@
                format
                           CDATA
                                     'svg'
+               scope
+                          (external |
+                           local |
+                           peer |
+                           -dita-use-conref-target)
+                                    #IMPLIED                                    
                parse
                           CDATA
                                     'xml'

--- a/doctypes/rng/technicalContent/svgDomain.rng
+++ b/doctypes/rng/technicalContent/svgDomain.rng
@@ -97,6 +97,16 @@ DITA SVG Domain
           <attribute name="format" a:defaultValue="svg"/>
         </optional>
         <optional>
+          <attribute name="scope">
+            <choice>
+              <value>external</value>
+              <value>local</value>
+              <value>peer</value>
+              <value>-dita-use-conref-target</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
           <attribute name="parse" a:defaultValue="xml"/>
         </optional>
         <optional>


### PR DESCRIPTION
Fixes based on this thread, as discussed at TC meeting November 10, 2020: https://lists.oasis-open.org/archives/dita/202011/msg00013.html

Adds the scope attribute to the svgref element; spec topic already indicates that it should be defined.