### PR TITLE
Fix attr list for body elements to univ-atts

### DIFF
--- a/doctypes/dtd/technicalContent/concept.mod
+++ b/doctypes/dtd/technicalContent/concept.mod
@@ -87,15 +87,7 @@
                           %conbodydiv;)*)"
 >
 <!ENTITY % conbody.attributes
-              "%id-atts;
-               %localization-atts;
-               base
-                          CDATA
-                                    #IMPLIED
-               %base-attribute-extensions;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  conbody %conbody.content;>
 <!ATTLIST  conbody %conbody.attributes;>

--- a/doctypes/dtd/technicalContent/glossentry.mod
+++ b/doctypes/dtd/technicalContent/glossentry.mod
@@ -140,15 +140,7 @@
                          (%glossAlt;)*)"
 >
 <!ENTITY % glossBody.attributes
-              "%id-atts;
-               %localization-atts;
-               base
-                          CDATA
-                                    #IMPLIED
-               %base-attribute-extensions;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  glossBody %glossBody.content;>
 <!ATTLIST  glossBody %glossBody.attributes;>

--- a/doctypes/dtd/technicalContent/reference.mod
+++ b/doctypes/dtd/technicalContent/reference.mod
@@ -93,15 +93,7 @@
                          %table;)*"
 >
 <!ENTITY % refbody.attributes
-              "%id-atts;
-               %localization-atts;
-               base
-                          CDATA
-                                    #IMPLIED
-               %base-attribute-extensions;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  refbody %refbody.content;>
 <!ATTLIST  refbody %refbody.attributes;>

--- a/doctypes/dtd/technicalContent/task.mod
+++ b/doctypes/dtd/technicalContent/task.mod
@@ -135,15 +135,7 @@
                          (%postreq;)*)"
 >
 <!ENTITY % taskbody.attributes
-              "%id-atts;
-               %localization-atts;
-               base
-                          CDATA
-                                    #IMPLIED
-               %base-attribute-extensions;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  taskbody %taskbody.content;>
 <!ATTLIST  taskbody %taskbody.attributes;>

--- a/doctypes/dtd/technicalContent/troubleshooting.mod
+++ b/doctypes/dtd/technicalContent/troubleshooting.mod
@@ -95,15 +95,7 @@
                          (%troubleSolution;)+)?"
 >
 <!ENTITY % troublebody.attributes
-              "%id-atts;
-               %localization-atts;
-               base
-                          CDATA
-                                    #IMPLIED
-               %base-attribute-extensions;
-               outputclass
-                          CDATA
-                                    #IMPLIED"
+              "%univ-atts;"
 >
 <!ELEMENT  troublebody %troublebody.content;>
 <!ATTLIST  troublebody %troublebody.attributes;>

--- a/doctypes/rng/technicalContent/conceptMod.rng
+++ b/doctypes/rng/technicalContent/conceptMod.rng
@@ -148,15 +148,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Concept//EN"
         </zeroOrMore>
       </define>
       <define name="conbody.attributes">
-        <ref name="id-atts"/>
-        <ref name="localization-atts"/>
-        <optional>
-          <attribute name="base"/>
-        </optional>
-        <ref name="base-attribute-extensions"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
+        <ref name="univ-atts"/>
       </define>
       <define name="conbody.element">
         <element name="conbody" dita:longName="Concept Body">

--- a/doctypes/rng/technicalContent/glossentryMod.rng
+++ b/doctypes/rng/technicalContent/glossentryMod.rng
@@ -244,15 +244,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Entry//EN"
         </zeroOrMore>
       </define>
       <define name="glossBody.attributes">
-        <ref name="id-atts"/>
-        <ref name="localization-atts"/>
-        <optional>
-          <attribute name="base"/>
-        </optional>
-        <ref name="base-attribute-extensions"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
+        <ref name="univ-atts"/>
       </define>
       <define name="glossBody.element">
         <element name="glossBody" dita:longName="Glossary Body">

--- a/doctypes/rng/technicalContent/referenceMod.rng
+++ b/doctypes/rng/technicalContent/referenceMod.rng
@@ -166,15 +166,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Reference//EN"
         </zeroOrMore>
       </define>
       <define name="refbody.attributes">
-        <ref name="id-atts"/>
-        <ref name="localization-atts"/>
-        <optional>
-          <attribute name="base"/>
-        </optional>
-        <ref name="base-attribute-extensions"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
+        <ref name="univ-atts"/>
       </define>
       <define name="refbody.element">
         <element name="refbody" dita:longName="Reference Body">

--- a/doctypes/rng/technicalContent/taskMod.rng
+++ b/doctypes/rng/technicalContent/taskMod.rng
@@ -269,15 +269,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
         </zeroOrMore>
       </define>
       <define name="taskbody.attributes">
-        <ref name="id-atts"/>
-        <ref name="localization-atts"/>
-        <optional>
-          <attribute name="base"/>
-        </optional>
-        <ref name="base-attribute-extensions"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
+        <ref name="univ-atts"/>
       </define>
       <define name="taskbody.element">
         <element name="taskbody" dita:longName="Task Body">

--- a/doctypes/rng/technicalContent/troubleshootingMod.rng
+++ b/doctypes/rng/technicalContent/troubleshootingMod.rng
@@ -168,15 +168,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Troubleshooting//EN"
         </optional>
       </define>
       <define name="troublebody.attributes">
-        <ref name="id-atts"/>
-        <ref name="localization-atts"/>
-        <optional>
-          <attribute name="base"/>
-        </optional>
-        <ref name="base-attribute-extensions"/>
-        <optional>
-          <attribute name="outputclass"/>
-        </optional>
+        <ref name="univ-atts"/>
       </define>
       <define name="troublebody.element">
         <element name="troublebody" dita:longName="Troubleshooting Body" dita:since="1.3">


### PR DESCRIPTION
Attribute list for OASIS specializations of `body` should match the `body` attribute list. This appears to be an oversight going back to DITA 1.1.