### PR TITLE
Grammar changes for oasis-tcs/dita#33 remove copyto

### DIFF
--- a/doctypes/dtd/bookmap/bookmap.mod
+++ b/doctypes/dtd/bookmap/bookmap.mod
@@ -120,9 +120,6 @@
                keys
                           CDATA
                                     #IMPLIED
-               copy-to
-                          CDATA
-                                    #IMPLIED
                %topicref-atts;
                %univ-atts;"
 >

--- a/doctypes/dtd/technicalContent/glossrefDomain.mod
+++ b/doctypes/dtd/technicalContent/glossrefDomain.mod
@@ -49,9 +49,6 @@
                keys
                           CDATA
                                     #REQUIRED
-               copy-to
-                          CDATA
-                                    #IMPLIED
                collection-type
                           (choice |
                            family |

--- a/doctypes/rng/bookmap/bookmapMod.rng
+++ b/doctypes/rng/bookmap/bookmapMod.rng
@@ -242,9 +242,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
       <optional>
         <attribute name="keys"/>
       </optional>
-      <optional>
-        <attribute name="copy-to"/>
-      </optional>
       <ref name="topicref-atts"/>
       <ref name="univ-atts"/>
     </define>

--- a/doctypes/rng/technicalContent/glossrefDomain.rng
+++ b/doctypes/rng/technicalContent/glossrefDomain.rng
@@ -76,9 +76,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Reference Domain//EN"
         </optional>
         <attribute name="keys"/>
         <optional>
-          <attribute name="copy-to"/>
-        </optional>
-        <optional>
           <attribute name="collection-type">
             <choice>
               <value>choice</value>


### PR DESCRIPTION
Removes copy-to from the grammar files in the tech comm package, per oasis-tcs/dita#33