### PR TITLE
Cleanup TC spec based on latest base updates

### DIFF
--- a/specification/archSpec/technicalContent/dita-generic-task-topic.dita
+++ b/specification/archSpec/technicalContent/dita-generic-task-topic.dita
@@ -27,10 +27,9 @@
 		</section>
 		<section id="section_0C8A068CDF1D498F9FF534D3CE88CF2F">
 			<title>The structure of the general task topic</title>
-			<p id="p_366CB29A7238470BA9070488F953FBDD">The <xmlelement>task</xmlelement> element is
-				the top-level element for the general task topic. The general task topic contains a
-					<xmlelement>title</xmlelement> and a <xmlelement>taskbody</xmlelement> with
-				optional alternative titles (<xmlelement>titlealts</xmlelement>), a short
+			<p id="p_366CB29A7238470BA9070488F953FBDD">The <xmlelement>task</xmlelement> element is the
+				top-level element for the general task topic. The general task topic contains a
+					<xmlelement>title</xmlelement> and a <xmlelement>taskbody</xmlelement>, a short
 				description or <xmlelement>abstract</xmlelement>, a <xmlelement>prolog</xmlelement>,
 				and <xmlelement>related-links</xmlelement>.</p>
 			<p id="p_7262A46437C34654BD4E46DC49BC6FD4">The following elements are described here

--- a/specification/archSpec/technicalContent/dita-task-topic.dita
+++ b/specification/archSpec/technicalContent/dita-task-topic.dita
@@ -20,10 +20,9 @@
 		</section>
 		<section id="section_709331EA92CE484FBEC8274342823932">
 			<title>The structure of the <xmlelement>task</xmlelement> topic</title>
-			<p id="p_14C0AF0152D04AC8A70306B49E22D705">The <xmlelement>task</xmlelement> element is
-				the top-level element for the strict task topic. The strict task document type
-				contains a <xmlelement>title</xmlelement> and a <xmlelement>taskbody</xmlelement>
-				with optional alternative titles (<xmlelement>titlealts</xmlelement>), a short
+			<p id="p_14C0AF0152D04AC8A70306B49E22D705">The <xmlelement>task</xmlelement> element is the
+				top-level element for the strict task topic. The strict task document type contains
+				a <xmlelement>title</xmlelement> and a <xmlelement>taskbody</xmlelement>, a short
 				description or <xmlelement>abstract</xmlelement>, a <xmlelement>prolog</xmlelement>,
 				and <xmlelement>related-links</xmlelement>.</p>
 			<p id="p_9286DB98E2CD47D0A53B40DFB0049E0C">The <xmlelement>taskbody</xmlelement> element

--- a/specification/archSpec/technicalContent/dita-troubleshooting-topic.dita
+++ b/specification/archSpec/technicalContent/dita-troubleshooting-topic.dita
@@ -36,14 +36,12 @@
 		</section> 
 	 <section id="structure">
 			<title>The structure of the troubleshooting topic</title>
-			<p>The top-level element for troubleshooting topics is
-					<xmlelement>troubleshooting</xmlelement>. The
-					<xmlelement>troubleshooting</xmlelement> element contains a
-					<xmlelement>title</xmlelement> with optional alternative titles
-					(<xmlelement>titlealts</xmlelement>), a short description or
-					<xmlelement>abstract</xmlelement>, a <xmlelement>prolog</xmlelement>, a
-					<xmlelement>troublebody</xmlelement>, and
-				<xmlelement>related-links</xmlelement>.</p>
+			<p>The top-level element for troubleshooting topics is <xmlelement>troubleshooting</xmlelement>.
+                The <xmlelement>troubleshooting</xmlelement> element contains a
+                    <xmlelement>title</xmlelement>, a short description or
+                    <xmlelement>abstract</xmlelement>, a <xmlelement>prolog</xmlelement>, a
+                    <xmlelement>troublebody</xmlelement>, and
+                <xmlelement>related-links</xmlelement>.</p>
 			<p><xmlelement>troublebody</xmlelement> is the main body element in a troubleshooting
 				topic. The <xmlelement>troublebody</xmlelement> element contains the following
 				elements:</p>

--- a/specification/common/conref-tc-attribute.dita
+++ b/specification/common/conref-tc-attribute.dita
@@ -10,7 +10,166 @@
                                 <title>Reused attribute set for glossentry</title>
                                 <p id="glossentry-specialized-title">The following attributes are available on this element: <xref
                                         keyref="attributes-universal"/> (without the Metadata attribute group) and
-                                        <xmlatt>base</xmlatt> from the <xref keyref="attributes-metadata"/>.</p>
+                                        <xref keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>.</p>
                         </section>
+                        <section>
+                                <title>Bookmap related attribute sections</title>
+                                <sectiondiv id="bookmap-booklist-attributes" platform="dita">
+                                        <p>The following attributes are available on this element: <ph
+                                                conkeyref="reuse-attributes/ref-universalatts"/>,
+                                                <ph conkeyref="reuse-attributes/ref-linkatts"/>
+                                                (with a narrowed definition of <xmlatt>href</xmlatt>, given
+                                                below), <ph conkeyref="reuse-attributes/ref-commonmapatts"
+                                                />, and <xref keyref="attributes-common/attr-keyref"
+                                                        ><xmlatt>keyref</xmlatt></xref>.</p>
+                                        <dl>
+                                                <dlentry id="href-for-booklist">
+                                                        <dt id="attr-href-booklist"
+                                                                ><xmlatt>href</xmlatt></dt>
+                                                        <dd>References a manual listing for the current
+                                                                element. See <xref
+                                                                        keyref="attributes-common/attr-href"
+                                                                        ><xmlatt>href</xmlatt></xref> for detailed
+                                                                information on supported values and processing
+                                                                implications. If no <xmlatt>href</xmlatt> is
+                                                                specified, processors can choose to generate an
+                                                                appropriate listing for this element. All of the
+                                                                book listings operate in a similar manner; for
+                                                                example, <codeph>&lt;toc
+                                                                        href="toc.dita"/&gt;</codeph> references a topic
+                                                                which contains a manual table of contents, while
+                                                                <codeph>&lt;toc/&gt;</codeph> indicates that a
+                                                                processor should generate the table of contents. </dd>
+                                                </dlentry>
+                                        </dl>
+                                </sectiondiv><sectiondiv id="bookmap-topicrefs" platform="dita">
+                                        <p>The following attributes are available on this element: <ph
+                                                conkeyref="reuse-attributes/ref-universalatts"/>,
+                                                <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+                                                        conkeyref="reuse-attributes/ref-commonmapatts"/>,
+                                                and <xref keyref="attributes-common/attr-keyref"
+                                                        ><xmlatt>keyref</xmlatt></xref>.</p>
+                                </sectiondiv><sectiondiv id="bookmap-frontbackmatter" platform="dita">
+                                        <p>The following attributes are available on this element: <ph
+                                                conkeyref="reuse-attributes/ref-universalatts"/>,
+                                                <ph conkeyref="reuse-attributes/ref-commonmapatts"
+                                                />, and <xref keyref="attributes-common/attr-keyref"
+                                                        ><xmlatt>keyref</xmlatt></xref>. This element also
+                                                uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and
+                                                <xmlatt>type</xmlatt> from <ph
+                                                        conkeyref="reuse-attributes/ref-linkatts"/>.</p>
+                                </sectiondiv>
+                        </section>
+                        <section id="section-2"><title>Reusable groups for syntax diagram elements</title><p>These tend to
+                                be similar, with tweaks in <xmlatt>importance</xmlatt>, or adding/removing <xref
+                                        keyref="attributes-common/attr-keyref"
+                                        ><xmlatt>keyref</xmlatt></xref>.</p><p><keyword>optreq-sectiondiv</keyword> is used by <xmlelement>delim</xmlelement>,
+                                                <xmlelement>repsep</xmlelement>. The
+                                                <xmlatt>importance</xmlatt> definition inside is also used
+                                                by <xmlelement>fragref</xmlelement>.</p><sectiondiv
+                                                        id="syntaxelement-optreq">
+                                                        <p>The following attributes are available on this element: <ph
+                                                                conkeyref="reuse-attributes/ref-universalatts"/>
+                                                                (with a narrowed definition of <xmlatt>importance</xmlatt>,
+                                                                given below).</p>
+                                                        <dl>
+                                                                <dlentry id="importance-optreq">
+                                                                        <dt id="attr-importance-syn2"
+                                                                                ><xmlatt>importance</xmlatt></dt>
+                                                                        <dd>The attribute indicates whether this item in a
+                                                                                syntax diagram is <keyword>optional</keyword> or
+                                                                                <keyword>required</keyword>. Output processors <ph
+                                                                                        >might</ph> indicate this
+                                                                                designation in a generated diagram. Allowable
+                                                                                values are: <dl>
+                                                                                        <dlentry>
+                                                                                                <dt>optional</dt>
+                                                                                                <dd>This section of the syntax is optional.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry>
+                                                                                                <dt>required</dt>
+                                                                                                <dd>This section of the syntax is required.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry conkeyref="reuse-attributes/ditauseconref">
+                                                                                                <dt/>
+                                                                                                <dd/>
+                                                                                        </dlentry>
+                                                                                </dl></dd>
+                                                                </dlentry>
+                                                        </dl>
+                                                </sectiondiv><sectiondiv id="syntaxelement-update-importance">
+                                                        <p>The following attributes are available on this element: <ph
+                                                                conkeyref="reuse-attributes/ref-universalatts"/>
+                                                                (with a narrowed definition of <xmlatt>importance</xmlatt>,
+                                                                given below).</p>
+                                                        <dl>
+                                                                <dlentry>
+                                                                        <dt id="attr-importance-syn3"
+                                                                                ><xmlatt>importance</xmlatt></dt>
+                                                                        <dd>The attribute indicates whether this item in a
+                                                                                syntax diagram is <keyword>optional</keyword>,
+                                                                                <keyword>required</keyword>, or
+                                                                                <keyword>default</keyword>. Output processors <ph
+                                                                                        >can</ph> indicate this
+                                                                                designation in a generated diagram. Allowable
+                                                                                values are: <dl>
+                                                                                        <dlentry>
+                                                                                                <dt>optional</dt>
+                                                                                                <dd>This section of the syntax is optional.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry>
+                                                                                                <dt>required</dt>
+                                                                                                <dd>This section of the syntax is required.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry>
+                                                                                                <dt>default</dt>
+                                                                                                <dd>This section of the syntax is used by default
+                                                                                                        or has this default value.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry conkeyref="reuse-attributes/ditauseconref">
+                                                                                                <dt/>
+                                                                                                <dd/>
+                                                                                        </dlentry>
+                                                                                </dl></dd>
+                                                                </dlentry>
+                                                        </dl>
+                                                </sectiondiv><sectiondiv id="syntaxelement-update-importance-plus-keyref">
+                                                        <p>The following attributes are available on this element: <ph
+                                                                conkeyref="reuse-attributes/ref-universalatts"/>
+                                                                (with a narrowed definition of <xmlatt>importance</xmlatt>,
+                                                                given below) and <xref keyref="attributes-common/attr-keyref"
+                                                                        ><xmlatt>keyref</xmlatt></xref>.</p>
+                                                        <dl>
+                                                                <dlentry>
+                                                                        <dt id="attr-importance-syn4"
+                                                                                ><xmlatt>importance</xmlatt></dt>
+                                                                        <dd>The attribute indicates whether this item in a
+                                                                                syntax diagram is <keyword>optional</keyword>,
+                                                                                <keyword>required</keyword>, or
+                                                                                <keyword>default</keyword>. Output processors <ph
+                                                                                        >might</ph> indicate this
+                                                                                designation in a generated diagram. Allowable
+                                                                                values are: <dl>
+                                                                                        <dlentry>
+                                                                                                <dt>optional</dt>
+                                                                                                <dd>This section of the syntax is optional.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry>
+                                                                                                <dt>required</dt>
+                                                                                                <dd>This section of the syntax is required.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry>
+                                                                                                <dt>default</dt>
+                                                                                                <dd>This section of the syntax is used by default
+                                                                                                        or has this default value.</dd>
+                                                                                        </dlentry>
+                                                                                        <dlentry conkeyref="reuse-attributes/ditauseconref">
+                                                                                                <dt/>
+                                                                                                <dd/>
+                                                                                        </dlentry>
+                                                                                </dl></dd>
+                                                                </dlentry>
+                                                        </dl>
+                                                </sectiondiv></section>
                 </conbody>
         </concept>

--- a/specification/common/conref-tc-attribute.dita
+++ b/specification/common/conref-tc-attribute.dita
@@ -8,8 +8,8 @@
                 <conbody>
                         <section>
                                 <title>Reused attribute set for glossentry</title>
-                                <p id="glossentry-specialized-title">The following attributes are available on this element: <xref
-                                        keyref="attributes-universal"/> (without the Metadata attribute group) and
+                                <p id="glossentry-specialized-title">The following attributes are available on this element: <ph
+                                        conkeyref="reuse-attributes/ref-universalatts"/> (without the Metadata attribute group) and
                                         <xref keyref="attributes-universal/attr-base"><xmlatt>base</xmlatt></xref>.</p>
                         </section>
                         <section>
@@ -76,25 +76,26 @@
                                                                 <dlentry id="importance-optreq">
                                                                         <dt id="attr-importance-syn2"
                                                                                 ><xmlatt>importance</xmlatt></dt>
-                                                                        <dd>The attribute indicates whether this item in a
-                                                                                syntax diagram is <keyword>optional</keyword> or
-                                                                                <keyword>required</keyword>. Output processors <ph
-                                                                                        >might</ph> indicate this
-                                                                                designation in a generated diagram. Allowable
-                                                                                values are: <dl>
-                                                                                        <dlentry>
-                                                                                                <dt>optional</dt>
-                                                                                                <dd>This section of the syntax is optional.</dd>
-                                                                                        </dlentry>
-                                                                                        <dlentry>
-                                                                                                <dt>required</dt>
-                                                                                                <dd>This section of the syntax is required.</dd>
-                                                                                        </dlentry>
-                                                                                        <dlentry conkeyref="reuse-attributes/ditauseconref">
-                                                                                                <dt/>
-                                                                                                <dd/>
-                                                                                        </dlentry>
-                                                                                </dl></dd>
+                                                                        <dd>The attribute indicates
+                                                  whether this item in a syntax diagram is
+                                                  <keyword>optional</keyword> or
+                                                  <keyword>required</keyword>. Output processors
+                                                  might indicate this designation in a generated
+                                                  diagram. Allowable values are: <dl>
+                                                  <dlentry>
+                                                  <dt>optional</dt>
+                                                  <dd>This section of the syntax is optional.</dd>
+                                                  </dlentry>
+                                                  <dlentry>
+                                                  <dt>required</dt>
+                                                  <dd>This section of the syntax is required.</dd>
+                                                  </dlentry>
+                                                  <dlentry
+                                                  conkeyref="reuse-attributes/ditauseconref">
+                                                  <dt/>
+                                                  <dd/>
+                                                  </dlentry>
+                                                  </dl></dd>
                                                                 </dlentry>
                                                         </dl>
                                                 </sectiondiv><sectiondiv id="syntaxelement-update-importance">
@@ -106,31 +107,32 @@
                                                                 <dlentry>
                                                                         <dt id="attr-importance-syn3"
                                                                                 ><xmlatt>importance</xmlatt></dt>
-                                                                        <dd>The attribute indicates whether this item in a
-                                                                                syntax diagram is <keyword>optional</keyword>,
-                                                                                <keyword>required</keyword>, or
-                                                                                <keyword>default</keyword>. Output processors <ph
-                                                                                        >can</ph> indicate this
-                                                                                designation in a generated diagram. Allowable
-                                                                                values are: <dl>
-                                                                                        <dlentry>
-                                                                                                <dt>optional</dt>
-                                                                                                <dd>This section of the syntax is optional.</dd>
-                                                                                        </dlentry>
-                                                                                        <dlentry>
-                                                                                                <dt>required</dt>
-                                                                                                <dd>This section of the syntax is required.</dd>
-                                                                                        </dlentry>
-                                                                                        <dlentry>
-                                                                                                <dt>default</dt>
-                                                                                                <dd>This section of the syntax is used by default
-                                                                                                        or has this default value.</dd>
-                                                                                        </dlentry>
-                                                                                        <dlentry conkeyref="reuse-attributes/ditauseconref">
-                                                                                                <dt/>
-                                                                                                <dd/>
-                                                                                        </dlentry>
-                                                                                </dl></dd>
+                                                                        <dd>The attribute indicates
+                                                  whether this item in a syntax diagram is
+                                                  <keyword>optional</keyword>,
+                                                  <keyword>required</keyword>, or
+                                                  <keyword>default</keyword>. Output processors can
+                                                  indicate this designation in a generated diagram.
+                                                  Allowable values are: <dl>
+                                                  <dlentry>
+                                                  <dt>optional</dt>
+                                                  <dd>This section of the syntax is optional.</dd>
+                                                  </dlentry>
+                                                  <dlentry>
+                                                  <dt>required</dt>
+                                                  <dd>This section of the syntax is required.</dd>
+                                                  </dlentry>
+                                                  <dlentry>
+                                                  <dt>default</dt>
+                                                  <dd>This section of the syntax is used by default
+                                                  or has this default value.</dd>
+                                                  </dlentry>
+                                                  <dlentry
+                                                  conkeyref="reuse-attributes/ditauseconref">
+                                                  <dt/>
+                                                  <dd/>
+                                                  </dlentry>
+                                                  </dl></dd>
                                                                 </dlentry>
                                                         </dl>
                                                 </sectiondiv><sectiondiv id="syntaxelement-update-importance-plus-keyref">

--- a/specification/dita-2.0-technical-content-specification.ditamap
+++ b/specification/dita-2.0-technical-content-specification.ditamap
@@ -31,6 +31,20 @@
     </bookrights>
   </bookmeta>
   <frontmatter>
+    <!-- These references to StubTopic need to refer to a copy of the base spec,
+      which should be published in some version before this map is processed. -->
+    <keydef keys="attributes-keys" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-keyscope" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-keyref" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-conref" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-conkeyref" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-conaction" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-conrefend" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-useconreftarget" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-href" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-format" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-scope" href="stubs/StubTopic.dita"/>
+    <keydef keys="attributes-type" href="stubs/StubTopic.dita"/>
     <topicref href="common/conref-cover-pages.dita" processing-role="resource-only"/>
     <keydef href="common/conref-tc-attribute.dita" keys="reuse-tc-attributes"/>
     <mapref href="baseSpec/specification/common/key-definitions-library-topics.ditamap"/>

--- a/specification/langRef/technicalContent/abbreviated-form.dita
+++ b/specification/langRef/technicalContent/abbreviated-form.dita
@@ -84,7 +84,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/abbreviated-form.dita
+++ b/specification/langRef/technicalContent/abbreviated-form.dita
@@ -84,7 +84,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/abbrevlist.dita
+++ b/specification/langRef/technicalContent/abbrevlist.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock xml:space="preserve">&lt;abbrevlist href="abbrev.dita"/&gt;</codeblock></example>

--- a/specification/langRef/technicalContent/addressdetails.dita
+++ b/specification/langRef/technicalContent/addressdetails.dita
@@ -19,7 +19,7 @@
       <p>The <xmlelement>addressdetails</xmlelement> is specialized from
         <xmlelement>ph</xmlelement>. It is defined in the XNAL domain.</p></section>
     <section id="attributes"><title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock> &lt;personinfo&gt;

--- a/specification/langRef/technicalContent/addressdetails.dita
+++ b/specification/langRef/technicalContent/addressdetails.dita
@@ -19,7 +19,7 @@
       <p>The <xmlelement>addressdetails</xmlelement> is specialized from
         <xmlelement>ph</xmlelement>. It is defined in the XNAL domain.</p></section>
     <section id="attributes"><title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock> &lt;personinfo&gt;

--- a/specification/langRef/technicalContent/administrativearea.dita
+++ b/specification/langRef/technicalContent/administrativearea.dita
@@ -20,7 +20,7 @@
          <p>The <xmlelement>administrativearea</xmlelement> element is specialized from
                <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p></section>
       <section id="attributes"><title>Attributes</title>
-         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </section>
       <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;addressdetails&gt;
 &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;

--- a/specification/langRef/technicalContent/administrativearea.dita
+++ b/specification/langRef/technicalContent/administrativearea.dita
@@ -20,7 +20,7 @@
          <p>The <xmlelement>administrativearea</xmlelement> element is specialized from
                <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p></section>
       <section id="attributes"><title>Attributes</title>
-         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+         <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </section>
       <example id="example" otherprops="examples"><title>Example</title><codeblock>&lt;addressdetails&gt;
 &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;

--- a/specification/langRef/technicalContent/amendments.dita
+++ b/specification/langRef/technicalContent/amendments.dita
@@ -23,7 +23,7 @@
     hierarchy</title>
       <p>The <xmlelement>amendments</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-  <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+  <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
   <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample specifies that a change history list is generated in the
         publication front matter. The content of the change history list is contained in the DITA

--- a/specification/langRef/technicalContent/apiname.dita
+++ b/specification/langRef/technicalContent/apiname.dita
@@ -22,7 +22,7 @@
          <p>The <xmlelement>apiname</xmlelement> is specialized from
                <xmlelement>keyword</xmlelement>. It is defined in the programming domain module.</p></section>
       <section id="attributes"><title>Attributes</title>
-         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+         <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </section>
       <example id="example" otherprops="examples"
          ><title>Example</title>

--- a/specification/langRef/technicalContent/apiname.dita
+++ b/specification/langRef/technicalContent/apiname.dita
@@ -22,7 +22,7 @@
          <p>The <xmlelement>apiname</xmlelement> is specialized from
                <xmlelement>keyword</xmlelement>. It is defined in the programming domain module.</p></section>
       <section id="attributes"><title>Attributes</title>
-         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       </section>
       <example id="example" otherprops="examples"
          ><title>Example</title>

--- a/specification/langRef/technicalContent/appendices.dita
+++ b/specification/langRef/technicalContent/appendices.dita
@@ -21,7 +21,7 @@
       <p>The <xmlelement>appendices</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>; it is defined in the bookmap module.</p></section>
     <section id="attributes"><title>Attributes</title><sectiondiv
-        conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+        conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock>&lt;appendices toc="yes" deliveryTarget="html">
   &lt;topicmeta>

--- a/specification/langRef/technicalContent/appendix.dita
+++ b/specification/langRef/technicalContent/appendix.dita
@@ -21,7 +21,7 @@
       <p>The <xmlelement>appendix</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>; it is defined in the bookmap module.</p></section>
     <section id="attributes"><title>Attributes</title><sectiondiv
-        conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+        conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples"><title>Example</title><p>Appendix topics that
         include
         subtopics:<codeblock xml:space="preserve">&lt;appendix href="intro.dita"&gt;

--- a/specification/langRef/technicalContent/backmatter.dita
+++ b/specification/langRef/technicalContent/backmatter.dita
@@ -20,7 +20,7 @@
    <p>The <xmlelement>backmatter</xmlelement> element is specialized from
      <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p>
   </section>
-  <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-attributes/bookmap-frontbackmatter"/></section>
+  <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-tc-attributes/bookmap-frontbackmatter"/></section>
   <example id="example" otherprops="examples">
    <title>Example</title>
    <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/bibliolist.dita
+++ b/specification/langRef/technicalContent/bibliolist.dita
@@ -26,7 +26,7 @@
         ><title>Specialization hierarchy</title>
       <p>The <xmlelement>bibliolist</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-    <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+    <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock>&lt;bookmap>
   &lt;!-- ... -->

--- a/specification/langRef/technicalContent/bookabstract.dita
+++ b/specification/langRef/technicalContent/bookabstract.dita
@@ -24,7 +24,7 @@
       <p>The <xmlelement>bookabstract</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
   <section id="attributes"><title>Attributes</title><sectiondiv
-    conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+    conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
   <example id="example" otherprops="examples"><title>Example</title><p>See the example in <xref
      href="bookmap.dita"/>.</p></example>
  </refbody>

--- a/specification/langRef/technicalContent/booklibrary.dita
+++ b/specification/langRef/technicalContent/booklibrary.dita
@@ -24,7 +24,7 @@
             <p>The <xmlelement>booklibrary</xmlelement> element is specialized from
                     <xmlelement>ph</xmlelement>; it is defined in the bookmap module.</p></section>
         <section id="attributes"><title>Attributes</title>
-            <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+            <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples"><title>Example</title><p>See the example in
                     <xref href="bookmap.dita"/>.</p></example>

--- a/specification/langRef/technicalContent/booklibrary.dita
+++ b/specification/langRef/technicalContent/booklibrary.dita
@@ -24,7 +24,7 @@
             <p>The <xmlelement>booklibrary</xmlelement> element is specialized from
                     <xmlelement>ph</xmlelement>; it is defined in the bookmap module.</p></section>
         <section id="attributes"><title>Attributes</title>
-            <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+            <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples"><title>Example</title><p>See the example in
                     <xref href="bookmap.dita"/>.</p></example>

--- a/specification/langRef/technicalContent/booklist.dita
+++ b/specification/langRef/technicalContent/booklist.dita
@@ -32,7 +32,7 @@
             <p>The <xmlelement>booklist</xmlelement> element is specialized from
                     <xmlelement>topicref</xmlelement>; it is defined in the bookmap module.</p></section>
         <section id="attributes"><title>Attributes</title><sectiondiv
-                conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+                conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
         <example id="example" otherprops="examples"><title>Example</title><p>In this case the
                     <xmlelement>booklist</xmlelement> element references a topic that contains a
                 list of authors of topics in this

--- a/specification/langRef/technicalContent/booklists.dita
+++ b/specification/langRef/technicalContent/booklists.dita
@@ -26,8 +26,8 @@
         <section id="attributes"><title>Attributes</title>
             <p>The following attributes are available on this element: <xref
                     keyref="attributes-universal"/>, <xref keyref="attributes-common/commonmapatts"
-                    />, <xref keyref="attributes-common/topicrefatts"/>, and <xref
-                    keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. This element also
+                    />, and <xref
+                    keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also
                 uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from
                     <xref keyref="attributes-common/linkatts"/>.</p>
         </section>

--- a/specification/langRef/technicalContent/booklists.dita
+++ b/specification/langRef/technicalContent/booklists.dita
@@ -25,11 +25,11 @@
         </section>
         <section id="attributes"><title>Attributes</title>
             <p>The following attributes are available on this element: <ph
-                    conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/commonmapatts"
+                    conkeyref="reuse-attributes/ref-universalatts"/>, <ph conkeyref="reuse-attributes/ref-commonmapatts"
                     />, and <xref
                     keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also
                 uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from
-                    <xref keyref="attributes-common/linkatts"/>.</p>
+                <ph conkeyref="reuse-attributes/ref-linkatts"/>.</p>
         </section>
         <example id="example" otherprops="examples"><title>Example</title>
             <p>The following code sample indicates that lists are generated in the front and back

--- a/specification/langRef/technicalContent/booklists.dita
+++ b/specification/langRef/technicalContent/booklists.dita
@@ -24,8 +24,8 @@
                     <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p>
         </section>
         <section id="attributes"><title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/>, <xref keyref="attributes-common/commonmapatts"
+            <p>The following attributes are available on this element: <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/commonmapatts"
                     />, and <xref
                     keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also
                 uses <xmlatt>scope</xmlatt>, <xmlatt>format</xmlatt>, and <xmlatt>type</xmlatt> from

--- a/specification/langRef/technicalContent/bookmeta.dita
+++ b/specification/langRef/technicalContent/bookmeta.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/standard-topicmeta-attributes"/></section>
+      <p conkeyref="reuse-attributes/only-universal"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In this example:<ul>

--- a/specification/langRef/technicalContent/booktitle.dita
+++ b/specification/langRef/technicalContent/booktitle.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/booktitlealt.dita
+++ b/specification/langRef/technicalContent/booktitlealt.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/booktitlealt.dita
+++ b/specification/langRef/technicalContent/booktitlealt.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/chapter.dita
+++ b/specification/langRef/technicalContent/chapter.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>Chapter topics that include

--- a/specification/langRef/technicalContent/chdesc.dita
+++ b/specification/langRef/technicalContent/chdesc.dita
@@ -19,7 +19,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />, <xref keyref="attributes-common/specentry"/>, and the attributes defined
         below.</p>
       <dl>

--- a/specification/langRef/technicalContent/chdesc.dita
+++ b/specification/langRef/technicalContent/chdesc.dita
@@ -20,7 +20,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        />, <xref keyref="attributes-common/specentry"/>, and the attributes defined
+        />, <xref keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the attributes defined
         below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/tablescope">

--- a/specification/langRef/technicalContent/chdeschd.dita
+++ b/specification/langRef/technicalContent/chdeschd.dita
@@ -18,7 +18,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />, <xref keyref="attributes-common/specentry"/>, and the attributes defined
         below.</p>
       <dl>

--- a/specification/langRef/technicalContent/chdeschd.dita
+++ b/specification/langRef/technicalContent/chdeschd.dita
@@ -19,7 +19,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        />, <xref keyref="attributes-common/specentry"/>, and the attributes defined
+        />, <xref keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the attributes defined
         below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/tablescope">

--- a/specification/langRef/technicalContent/chhead.dita
+++ b/specification/langRef/technicalContent/chhead.dita
@@ -15,7 +15,7 @@
 <p>The <xmlelement>chhead</xmlelement> element is specialized from <xmlelement>sthead</xmlelement>.
         It is defined in the task module.</p>
 </section><section id="attributes"><title>Attributes</title>
-      <!--<p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>-->
+      <!--<p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>-->
    </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/technicalContent/choice.dita
+++ b/specification/langRef/technicalContent/choice.dita
@@ -10,7 +10,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <!--<p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>-->
+      <!--<p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>-->
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/choices.dita
+++ b/specification/langRef/technicalContent/choices.dita
@@ -7,7 +7,7 @@
 <p>The <xmlelement>choices</xmlelement> element is specialized from <xmlelement>ul</xmlelement>. It
         is defined in the task module.</p>
 </section><section id="attributes"><title>Attributes</title>
-      <!--<p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>-->
+      <!--<p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>-->
       </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/choicetable.dita
+++ b/specification/langRef/technicalContent/choicetable.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
       />, <xref keyref="attributes-common/displayatts"/>, <xref keyref="attributes-common/simpletableatts"/> (with a
         narrowed definition of <xmlatt>keycol</xmlatt>, given below), and <xref
           keyref="attributes-common/spectitle"/>.<dl>

--- a/specification/langRef/technicalContent/choicetable.dita
+++ b/specification/langRef/technicalContent/choicetable.dita
@@ -29,9 +29,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-      />, <xref keyref="attributes-common/displayatts"/>, <xref keyref="attributes-common/simpletableatts"/> (with a
+      />, <ph keyref="reuse-attributes/ref-displayatts"/>, <ph conkeyref="reuse-attributes/ref-simpletableatts"/> (with a
         narrowed definition of <xmlatt>keycol</xmlatt>, given below), and <xref
-          keyref="attributes-common/spectitle"/>.<dl>
+          keyref="attributes-common/attr-spectitle"><xmlatt>spectitle</xmlatt></xref>.<dl>
           <dlentry>
             <dt><xmlatt>keycol</xmlatt></dt>
             <dd>Defines the column that contains headings for each row. The default value for

--- a/specification/langRef/technicalContent/choption.dita
+++ b/specification/langRef/technicalContent/choption.dita
@@ -10,7 +10,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />, <xref keyref="attributes-common/specentry"/>, and the attributes defined
         below.</p>
       <dl>

--- a/specification/langRef/technicalContent/choption.dita
+++ b/specification/langRef/technicalContent/choption.dita
@@ -10,9 +10,10 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        />, <xref keyref="attributes-common/specentry"/>, and the attributes defined
-        below.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the
+        attributes defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/tablescope">
           <dt/>

--- a/specification/langRef/technicalContent/choptionhd.dita
+++ b/specification/langRef/technicalContent/choptionhd.dita
@@ -19,8 +19,8 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"
+         <p>The following attributes are available on this element: <ph
+               conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"
             />, and the attributes defined below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/tablescope">

--- a/specification/langRef/technicalContent/choptionhd.dita
+++ b/specification/langRef/technicalContent/choptionhd.dita
@@ -20,8 +20,9 @@
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <ph
-               conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"
-            />, and the attributes defined below.</p>
+               conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+               keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the
+            attributes defined below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/tablescope">
                <dt/>

--- a/specification/langRef/technicalContent/chrow.dita
+++ b/specification/langRef/technicalContent/chrow.dita
@@ -12,7 +12,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/cmd.dita
+++ b/specification/langRef/technicalContent/cmd.dita
@@ -15,7 +15,7 @@
             defined in the task module.</p>
 </section>
 <section id="attributes"><title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
    </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/technicalContent/cmd.dita
+++ b/specification/langRef/technicalContent/cmd.dita
@@ -15,7 +15,7 @@
             defined in the task module.</p>
 </section>
 <section id="attributes"><title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
    </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/technicalContent/cmdname.dita
+++ b/specification/langRef/technicalContent/cmdname.dita
@@ -23,7 +23,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/cmdname.dita
+++ b/specification/langRef/technicalContent/cmdname.dita
@@ -23,7 +23,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />, <xref keyref="attributes-common/displayatts"/>, <xref keyref="attributes-common/xmlspace"/>, and
           <xref keyref="attributes-common/spectitle"/>.</p>
     </section>

--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -27,9 +27,11 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        />, <xref keyref="attributes-common/displayatts"/>, <xref keyref="attributes-common/xmlspace"/>, and
-          <xref keyref="attributes-common/spectitle"/>.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          keyref="reuse-attributes/ref-displayatts"/>, <xref keyref="attributes-common/xmlspace"
+            ><xmlatt>xml:space</xmlatt></xref>, and <xref keyref="attributes-common/attr-spectitle"
+            ><xmlatt>spectitle</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/codeph.dita
+++ b/specification/langRef/technicalContent/codeph.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/codeph.dita
+++ b/specification/langRef/technicalContent/codeph.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -31,8 +31,8 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p id="xref-attributes">The following attributes are available on this element: <xref
-keyref="attributes-universal"/>, <xref keyref="attributes-common/encoding"
+      <p id="xref-attributes">The following attributes are available on this element: <ph
+conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/encoding"
 ><xmlatt>encoding</xmlatt></xref>, <xref keyref="attributes-common/parse"
 ><xmlatt>parse</xmlatt></xref> (with a default value of "text"), <xref
 keyref="attributes-common/linkatts"/>, and <xref keyref="attributes-common/attr-keyref"

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -34,8 +34,8 @@
       <p id="xref-attributes">The following attributes are available on this element: <ph
 conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/encoding"
 ><xmlatt>encoding</xmlatt></xref>, <xref keyref="attributes-common/parse"
-><xmlatt>parse</xmlatt></xref> (with a default value of "text"), <xref
-keyref="attributes-common/linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
+><xmlatt>parse</xmlatt></xref> (with a default value of "text"), <ph
+  conkeyref="reuse-attributes/ref-linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
 ><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -35,7 +35,7 @@
 keyref="attributes-universal"/>, <xref keyref="attributes-common/encoding"
 ><xmlatt>encoding</xmlatt></xref>, <xref keyref="attributes-common/parse"
 ><xmlatt>parse</xmlatt></xref> (with a default value of "text"), <xref
-keyref="attributes-common/linkatts"/>, and <xref keyref="attributes-keyref"
+keyref="attributes-common/linkatts"/>, and <xref keyref="attributes-common/attr-keyref"
 ><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/colophon.dita
+++ b/specification/langRef/technicalContent/colophon.dita
@@ -31,7 +31,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;bookmap>

--- a/specification/langRef/technicalContent/completed.dita
+++ b/specification/langRef/technicalContent/completed.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/completed.dita
+++ b/specification/langRef/technicalContent/completed.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/conbodydiv.dita
+++ b/specification/langRef/technicalContent/conbodydiv.dita
@@ -35,7 +35,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/context.dita
+++ b/specification/langRef/technicalContent/context.dita
@@ -18,7 +18,7 @@
                         <xmlelement>section</xmlelement>. It is defined in the task module.</p>
 </section>
 <section id="attributes">       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
         </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/technicalContent/country.dita
+++ b/specification/langRef/technicalContent/country.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/country.dita
+++ b/specification/langRef/technicalContent/country.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/day.dita
+++ b/specification/langRef/technicalContent/day.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/day.dita
+++ b/specification/langRef/technicalContent/day.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/dedication.dita
+++ b/specification/langRef/technicalContent/dedication.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;frontmatter>

--- a/specification/langRef/technicalContent/delim.dita
+++ b/specification/langRef/technicalContent/delim.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-optreq"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-optreq"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>delim</xmlelement> element specifies that the

--- a/specification/langRef/technicalContent/draftintro.dita
+++ b/specification/langRef/technicalContent/draftintro.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;frontmatter>

--- a/specification/langRef/technicalContent/equation-block.dita
+++ b/specification/langRef/technicalContent/equation-block.dita
@@ -37,7 +37,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/equation-figure.dita
+++ b/specification/langRef/technicalContent/equation-figure.dita
@@ -51,9 +51,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-                                        keyref="attributes-common/displayatts"/>, and <xref
-                                        keyref="attributes-common/spectitle"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+        conkeyref="reuse-attributes/ref-displayatts"/>, and <xref
+                                        keyref="attributes-common/attr-spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/equation-figure.dita
+++ b/specification/langRef/technicalContent/equation-figure.dita
@@ -51,7 +51,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>, <xref
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <xref
                                         keyref="attributes-common/displayatts"/>, and <xref
                                         keyref="attributes-common/spectitle"/>.</p>
     </section>

--- a/specification/langRef/technicalContent/equation-inline.dita
+++ b/specification/langRef/technicalContent/equation-inline.dita
@@ -34,7 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/equation-inline.dita
+++ b/specification/langRef/technicalContent/equation-inline.dita
@@ -34,7 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/equation-number.dita
+++ b/specification/langRef/technicalContent/equation-number.dita
@@ -42,7 +42,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/figurelist.dita
+++ b/specification/langRef/technicalContent/figurelist.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/filepath.dita
+++ b/specification/langRef/technicalContent/filepath.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/filepath.dita
+++ b/specification/langRef/technicalContent/filepath.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/fragment.dita
+++ b/specification/langRef/technicalContent/fragment.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/fragref.dita
+++ b/specification/langRef/technicalContent/fragref.dita
@@ -24,7 +24,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         /> (with a narrowed definition of <xmlatt>importance</xmlatt>, given below) and the attributes defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/technicalContent/fragref.dita
+++ b/specification/langRef/technicalContent/fragref.dita
@@ -31,7 +31,7 @@
           <dt><xmlatt>href</xmlatt></dt>
           <dd>A reference to a syntax diagram <xmlelement>fragment</xmlelement> element. The
             referenced <xmlelement>fragment</xmlelement> must be in the same diagram as the
-            <xmlelement>fragref</xmlelement> element. See <xref keyref="attributes-href"/> for
+            <xmlelement>fragref</xmlelement> element. See <xref keyref="attributes-common/attr-href"/> for
             detailed information on supported values and processing
             implications.<!--For this element, processors <ph rev="public-review-1">can</ph> assume the equivalent of <codeph>scope="local"</codeph> and <codeph>format="dita"</codeph>.--></dd>
         </dlentry>

--- a/specification/langRef/technicalContent/frontmatter.dita
+++ b/specification/langRef/technicalContent/frontmatter.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-frontbackmatter"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-frontbackmatter"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/glossAlt.dita
+++ b/specification/langRef/technicalContent/glossAlt.dita
@@ -34,7 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/glossAlternateFor.dita
+++ b/specification/langRef/technicalContent/glossAlternateFor.dita
@@ -27,8 +27,8 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-        keyref="attributes-universal"/>, <xref
+      <p>The following attributes are available on this element: <ph
+        conkeyref="reuse-attributes/ref-universalatts"/>, <xref
             keyref="attributes-common/linkatts"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), and <xref
             keyref="attributes-common/attr-keyref"

--- a/specification/langRef/technicalContent/glossAlternateFor.dita
+++ b/specification/langRef/technicalContent/glossAlternateFor.dita
@@ -28,8 +28,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-        conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-            keyref="attributes-common/linkatts"/> (with a narrowed definition of
+        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+          conkeyref="reuse-attributes/ref-linkatts"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), and <xref
             keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>.<dl>

--- a/specification/langRef/technicalContent/glossAlternateFor.dita
+++ b/specification/langRef/technicalContent/glossAlternateFor.dita
@@ -31,7 +31,7 @@
         keyref="attributes-universal"/>, <xref
             keyref="attributes-common/linkatts"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), and <xref
-            keyref="attributes-keyref"
+            keyref="attributes-common/attr-keyref"
           ><xmlatt>keyref</xmlatt></xref>.<dl>
           <dlentry>
             <dt><xmlatt>href</xmlatt></dt>
@@ -40,7 +40,7 @@
               often be to another <xmlelement>glossAlt</xmlelement> element within the same
                 <xmlelement>glossentry</xmlelement> topic, indicating that the current variant is an
               alternate for both the primary term and the referenced alternate term. See <xref
-                keyref="attributes-href"/> for details on syntax.</dd>
+                keyref="attributes-common/attr-href"/> for details on syntax.</dd>
           </dlentry>
         </dl></p>
     </section>

--- a/specification/langRef/technicalContent/glossPartOfSpeech.dita
+++ b/specification/langRef/technicalContent/glossPartOfSpeech.dita
@@ -33,8 +33,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
         keyref="attributes-common/dataatts"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
-        given below), <xref keyref="attributes-common/linkatts"/>, and <xref
-          keyref="attributes-universal"/>.</p>
+        given below), <xref keyref="attributes-common/linkatts"/>, and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <dl>
         <dlentry>
           <dt id="value"><xmlatt>value</xmlatt></dt>

--- a/specification/langRef/technicalContent/glossPartOfSpeech.dita
+++ b/specification/langRef/technicalContent/glossPartOfSpeech.dita
@@ -31,9 +31,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-        keyref="attributes-common/dataatts"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
-        given below), <xref keyref="attributes-common/linkatts"/>, and <ph
+      <p>The following attributes are available on this element: <ph
+        conkeyref="reuse-attributes/ref-dataatts"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
+        given below), <ph conkeyref="reuse-attributes/ref-linkatts"/>, and <ph
           conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/technicalContent/glossStatus.dita
+++ b/specification/langRef/technicalContent/glossStatus.dita
@@ -33,8 +33,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
         keyref="attributes-common/dataatts"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
-        given below), <xref keyref="attributes-common/linkatts"/>, and <xref
-          keyref="attributes-universal"/>.</p>
+        given below), <xref keyref="attributes-common/linkatts"/>, and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <dl>
         <dlentry>
           <dt id="value"><xmlatt>value</xmlatt></dt>

--- a/specification/langRef/technicalContent/glossStatus.dita
+++ b/specification/langRef/technicalContent/glossStatus.dita
@@ -31,9 +31,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-        keyref="attributes-common/dataatts"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
-        given below), <xref keyref="attributes-common/linkatts"/>, and <ph
+      <p>The following attributes are available on this element: <ph
+        conkeyref="attributes-common/ref-dataatts"/> (with a narrowed definition of <xmlatt>value</xmlatt>,
+        given below), <ph conkeyref="attributes-common/ref-linkatts"/>, and <ph
           conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/technicalContent/glossSurfaceForm.dita
+++ b/specification/langRef/technicalContent/glossSurfaceForm.dita
@@ -34,7 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/glossSymbol.dita
+++ b/specification/langRef/technicalContent/glossSymbol.dita
@@ -20,8 +20,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <!--RDA: Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of hazardsymbol.-->
-      <p>The following attributes are available on this element: <xref
-        keyref="attributes-universal"/>, <xref
+      <p>The following attributes are available on this element: <ph
+        conkeyref="reuse-attributes/ref-universalatts"/>, <xref
             keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>

--- a/specification/langRef/technicalContent/glossSymbol.dita
+++ b/specification/langRef/technicalContent/glossSymbol.dita
@@ -22,7 +22,7 @@
       <!--RDA: Note that this is an exact copy of the attribute list for image, EXCEPT that this element dropped the deprecated alt and makes @href required, which makes it harder to reuse that full list. It is an exact copy of hazardsymbol.-->
       <p>The following attributes are available on this element: <xref
         keyref="attributes-universal"/>, <xref
-            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/image-href">

--- a/specification/langRef/technicalContent/glossarylist.dita
+++ b/specification/langRef/technicalContent/glossarylist.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/glossref.dita
+++ b/specification/langRef/technicalContent/glossref.dita
@@ -30,15 +30,15 @@ and expanded versions of that acronym.</shortdesc>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-        conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-              keyref="attributes-common/linkatts"/> (with a narrowed definition of
+        conkeyref="reuse-attributes/ref-universalatts"/>, <ph
+              conkeyref="attributes-common/ref-linkatts"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
             keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below. This element also uses <xmlatt>processing-role</xmlatt>,
           <xmlatt>collection-type</xmlatt>, <xmlatt>chunk</xmlatt>, and
-        <xmlatt>search</xmlatt> from <xref keyref="attributes-common/commonmapatts"/>; this
+        <xmlatt>search</xmlatt> from <ph conkeyref="attributes-common/ref-commonmapatts"/>; this
         element also uses narrowed definitions of <xmlatt>linking</xmlatt> and <xmlatt>toc</xmlatt>
-        from <xref keyref="attributes-common/commonmapatts"/>, given below.<dl>
+        from <ph conkeyref="attributes-common/ref-commonmapatts"/>, given below.<dl>
           <dlentry>
             <dt><xmlatt>href</xmlatt></dt>
             <dd>A pointer to a glossary definition, typically a <xmlelement>glossentry</xmlelement>

--- a/specification/langRef/technicalContent/glossref.dita
+++ b/specification/langRef/technicalContent/glossref.dita
@@ -31,10 +31,9 @@ and expanded versions of that acronym.</shortdesc>
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref
         keyref="attributes-universal"/>, <xref
-          keyref="attributes-common/topicrefatts"/>, <xref
               keyref="attributes-common/linkatts"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
-            keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>, and the
+            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the
         attributes defined below. This element also uses <xmlatt>processing-role</xmlatt>,
           <xmlatt>collection-type</xmlatt>, <xmlatt>chunk</xmlatt>, and
         <xmlatt>search</xmlatt> from <xref keyref="attributes-common/commonmapatts"/>; this
@@ -43,7 +42,7 @@ and expanded versions of that acronym.</shortdesc>
           <dlentry>
             <dt><xmlatt>href</xmlatt></dt>
             <dd>A pointer to a glossary definition, typically a <xmlelement>glossentry</xmlelement>
-              topic. See <xref keyref="attributes-href"/> for detailed information
+              topic. See <xref keyref="attributes-common/attr-href"/> for detailed information
               on supported values and processing implications. <ph
                 conkeyref="reuse-attributes/non-dita-href"/></dd>
           </dlentry>
@@ -51,7 +50,7 @@ and expanded versions of that acronym.</shortdesc>
             <dt><xmlatt>keys</xmlatt>
               <ph conkeyref="reuse-attributes/required-attr"/></dt>
             <dd>Associates one or more space-delimited keys with the target of the glossary
-              reference. See <xref keyref="attributes-keys"/> for information on
+              reference. See <xref keyref="attributes-common/attr-keys"/> for information on
               using the attribute.</dd>
           </dlentry>
           <dlentry conkeyref="reuse-attributes/toc-default-no">

--- a/specification/langRef/technicalContent/glossref.dita
+++ b/specification/langRef/technicalContent/glossref.dita
@@ -29,8 +29,8 @@ and expanded versions of that acronym.</shortdesc>
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref
-        keyref="attributes-universal"/>, <xref
+      <p>The following attributes are available on this element: <ph
+        conkeyref="reuse-attributes/ref-universalatts"/>, <xref
               keyref="attributes-common/linkatts"/> (with a narrowed definition of
           <xmlatt>href</xmlatt>, given below), <xref
             keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the

--- a/specification/langRef/technicalContent/groupchoice.dita
+++ b/specification/langRef/technicalContent/groupchoice.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-update-importance"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;syntaxdiagram frame="bottom"&gt;

--- a/specification/langRef/technicalContent/groupcomp.dita
+++ b/specification/langRef/technicalContent/groupcomp.dita
@@ -31,7 +31,7 @@ separated by a horizontal or vertical line, which is the usual formatting method
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-update-importance"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;syntaxdiagram frame="bottom"&gt;

--- a/specification/langRef/technicalContent/groupseq.dita
+++ b/specification/langRef/technicalContent/groupseq.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-update-importance"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample</p>

--- a/specification/langRef/technicalContent/hwcontrol.dita
+++ b/specification/langRef/technicalContent/hwcontrol.dita
@@ -29,7 +29,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and <xref keyref="attributes-keyref"
+                    keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/hwcontrol.dita
+++ b/specification/langRef/technicalContent/hwcontrol.dita
@@ -28,8 +28,8 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"
+            <p>The following attributes are available on this element: <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/indexlist.dita
+++ b/specification/langRef/technicalContent/indexlist.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/info.dita
+++ b/specification/langRef/technicalContent/info.dita
@@ -16,7 +16,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+         <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       </section>
       <example id="example" otherprops="examples">
          <title>Example</title>

--- a/specification/langRef/technicalContent/kwd.dita
+++ b/specification/langRef/technicalContent/kwd.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-update-importance-plus-keyref"
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance-plus-keyref"
       /></section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/locality.dita
+++ b/specification/langRef/technicalContent/locality.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/locality.dita
+++ b/specification/langRef/technicalContent/locality.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/localityname.dita
+++ b/specification/langRef/technicalContent/localityname.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/localityname.dita
+++ b/specification/langRef/technicalContent/localityname.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/mainbooktitle.dita
+++ b/specification/langRef/technicalContent/mainbooktitle.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/mainbooktitle.dita
+++ b/specification/langRef/technicalContent/mainbooktitle.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/markupname.dita
+++ b/specification/langRef/technicalContent/markupname.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/markupname.dita
+++ b/specification/langRef/technicalContent/markupname.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/mathml.dita
+++ b/specification/langRef/technicalContent/mathml.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -59,7 +59,7 @@
 keyref="attributes-common/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
         "xml"), and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses
 <xmlatt>href</xmlatt>, <xmlatt>scope</xmlatt>, and a narrowed definition of <xmlatt>format</xmlatt>
-        (given below) from <xref keyref="attributes-common/linkatts"/>.</p>
+        (given below) from <ph conkeyref="attributes-common/ref-linkatts"/>.</p>
       <dl>
         <dlentry>
           <dt><xmlatt>format</xmlatt></dt>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -54,7 +54,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
 />, <xref keyref="attributes-common/encoding"><xmlatt>encoding</xmlatt></xref>, <xref
 keyref="attributes-common/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
         "xml"), and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -57,7 +57,7 @@
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
 />, <xref keyref="attributes-common/encoding"><xmlatt>encoding</xmlatt></xref>, <xref
 keyref="attributes-common/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
-        "xml"), and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses
+        "xml"), and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses
 <xmlatt>href</xmlatt>, <xmlatt>scope</xmlatt>, and a narrowed definition of <xmlatt>format</xmlatt>
         (given below) from <xref keyref="attributes-common/linkatts"/>.</p>
       <dl>

--- a/specification/langRef/technicalContent/menucascade.dita
+++ b/specification/langRef/technicalContent/menucascade.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/menucascade.dita
+++ b/specification/langRef/technicalContent/menucascade.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/month.dita
+++ b/specification/langRef/technicalContent/month.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/month.dita
+++ b/specification/langRef/technicalContent/month.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/msgblock.dita
+++ b/specification/langRef/technicalContent/msgblock.dita
@@ -35,8 +35,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        />, <xref keyref="attributes-common/displayatts"/>, <xref keyref="attributes-common/xmlspace"/>, and
-          <xref keyref="attributes-common/spectitle"/>.</p>
+      />, <ph conkeyref="reuse-attributes/ref-displayatts"/>, <xref keyref="attributes-common/xmlspace"/>, and
+          <xref keyref="attributes-common/attr-spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/msgblock.dita
+++ b/specification/langRef/technicalContent/msgblock.dita
@@ -34,7 +34,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />, <xref keyref="attributes-common/displayatts"/>, <xref keyref="attributes-common/xmlspace"/>, and
           <xref keyref="attributes-common/spectitle"/>.</p>
     </section>

--- a/specification/langRef/technicalContent/msgnum.dita
+++ b/specification/langRef/technicalContent/msgnum.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/msgnum.dita
+++ b/specification/langRef/technicalContent/msgnum.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/msgph.dita
+++ b/specification/langRef/technicalContent/msgph.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/msgph.dita
+++ b/specification/langRef/technicalContent/msgph.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/notices.dita
+++ b/specification/langRef/technicalContent/notices.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>This example references a notices topic that contains legal content.</p>

--- a/specification/langRef/technicalContent/numcharref.dita
+++ b/specification/langRef/technicalContent/numcharref.dita
@@ -31,7 +31,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+        /> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/numcharref.dita
+++ b/specification/langRef/technicalContent/numcharref.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         /> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/oper.dita
+++ b/specification/langRef/technicalContent/oper.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-update-importance"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>oper</xmlelement> element specifies that the

--- a/specification/langRef/technicalContent/option.dita
+++ b/specification/langRef/technicalContent/option.dita
@@ -25,7 +25,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/option.dita
+++ b/specification/langRef/technicalContent/option.dita
@@ -25,7 +25,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/organizationname.dita
+++ b/specification/langRef/technicalContent/organizationname.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/organizationname.dita
+++ b/specification/langRef/technicalContent/organizationname.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/organizationnamedetails.dita
+++ b/specification/langRef/technicalContent/organizationnamedetails.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/organizationnamedetails.dita
+++ b/specification/langRef/technicalContent/organizationnamedetails.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/parameterentity.dita
+++ b/specification/langRef/technicalContent/parameterentity.dita
@@ -32,7 +32,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
-        /> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+        /> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Examples</title>

--- a/specification/langRef/technicalContent/parameterentity.dita
+++ b/specification/langRef/technicalContent/parameterentity.dita
@@ -31,7 +31,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         /> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/parmname.dita
+++ b/specification/langRef/technicalContent/parmname.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/parmname.dita
+++ b/specification/langRef/technicalContent/parmname.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/part.dita
+++ b/specification/langRef/technicalContent/part.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>Part topics that include chapters and

--- a/specification/langRef/technicalContent/partno.dita
+++ b/specification/langRef/technicalContent/partno.dita
@@ -21,7 +21,7 @@
         <section id="attributes">
             <title>Attributes</title>
             <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and <xref keyref="attributes-keyref"
+                    keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example otherprops="examples">

--- a/specification/langRef/technicalContent/partno.dita
+++ b/specification/langRef/technicalContent/partno.dita
@@ -20,8 +20,8 @@
         </section>
         <section id="attributes">
             <title>Attributes</title>
-            <p>The following attributes are available on this element: <xref
-                    keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"
+            <p>The following attributes are available on this element: <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"
                         ><xmlatt>keyref</xmlatt></xref>.</p>
         </section>
         <example otherprops="examples">

--- a/specification/langRef/technicalContent/pd.dita
+++ b/specification/langRef/technicalContent/pd.dita
@@ -23,7 +23,7 @@ the programming domain module.</p>
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/plentry.dita
+++ b/specification/langRef/technicalContent/plentry.dita
@@ -24,7 +24,7 @@ defined in the programming domain module.</p>
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/postalcode.dita
+++ b/specification/langRef/technicalContent/postalcode.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/postalcode.dita
+++ b/specification/langRef/technicalContent/postalcode.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/postreq.dita
+++ b/specification/langRef/technicalContent/postreq.dita
@@ -10,7 +10,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/preface.dita
+++ b/specification/langRef/technicalContent/preface.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-topicrefs"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/prereq.dita
+++ b/specification/langRef/technicalContent/prereq.dita
@@ -25,7 +25,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
   </section>
   <example id="example" otherprops="examples">
    <title>Example</title>

--- a/specification/langRef/technicalContent/propdesc.dita
+++ b/specification/langRef/technicalContent/propdesc.dita
@@ -19,8 +19,8 @@ values.</shortdesc>
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"
+         <p>The following attributes are available on this element: <ph
+               conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"
             />, and the attributes defined below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/stentry-rowspan">

--- a/specification/langRef/technicalContent/propdeschd.dita
+++ b/specification/langRef/technicalContent/propdeschd.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         />, <xref keyref="attributes-common/specentry"/>, and the attributes defined
         below.</p>
       <dl>

--- a/specification/langRef/technicalContent/property.dita
+++ b/specification/langRef/technicalContent/property.dita
@@ -24,7 +24,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+         <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       </section>
       <example id="example" otherprops="examples">
          <title>Example</title>

--- a/specification/langRef/technicalContent/prophead.dita
+++ b/specification/langRef/technicalContent/prophead.dita
@@ -19,7 +19,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+         <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       </section>
       <example id="example" otherprops="examples">
          <title>Example</title>

--- a/specification/langRef/technicalContent/proptype.dita
+++ b/specification/langRef/technicalContent/proptype.dita
@@ -17,8 +17,8 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"
+         <p>The following attributes are available on this element: <ph
+               conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"
             />, and the attributes defined below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/stentry-rowspan">

--- a/specification/langRef/technicalContent/proptypehd.dita
+++ b/specification/langRef/technicalContent/proptypehd.dita
@@ -19,8 +19,8 @@ type column of a properties table.</shortdesc>
             </section>
             <section id="attributes">
                   <title>Attributes</title>
-                  <p>The following attributes are available on this element: <xref
-                        keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"/>, and
+                  <p>The following attributes are available on this element: <ph
+                        conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"/>, and
                         the attributes defined below.</p>
                   <dl>
                         <dlentry conkeyref="reuse-attributes/tablescope">

--- a/specification/langRef/technicalContent/propvalue.dita
+++ b/specification/langRef/technicalContent/propvalue.dita
@@ -24,8 +24,8 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"
+         <p>The following attributes are available on this element: <ph
+               conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"
             />, and the attributes defined below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/stentry-rowspan">

--- a/specification/langRef/technicalContent/propvaluehd.dita
+++ b/specification/langRef/technicalContent/propvaluehd.dita
@@ -19,8 +19,8 @@ value column of a properties table.</shortdesc>
       </section>
       <section id="attributes">
          <title>Attributes</title>
-         <p>The following attributes are available on this element: <xref
-               keyref="attributes-universal"/>, <xref keyref="attributes-common/specentry"
+         <p>The following attributes are available on this element: <ph
+               conkeyref="reuse-attributes/ref-universalatts"/>, <xref keyref="attributes-common/specentry"
             />, and the attributes defined below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/tablescope">

--- a/specification/langRef/technicalContent/pt.dita
+++ b/specification/langRef/technicalContent/pt.dita
@@ -23,7 +23,7 @@ the programming domain module.</p>
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/pt.dita
+++ b/specification/langRef/technicalContent/pt.dita
@@ -23,7 +23,7 @@ the programming domain module.</p>
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/refbodydiv.dita
+++ b/specification/langRef/technicalContent/refbodydiv.dita
@@ -32,7 +32,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/repsep.dita
+++ b/specification/langRef/technicalContent/repsep.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-optreq"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-optreq"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In this example, the group can be repeated. When repeated, a comma should be used between

--- a/specification/langRef/technicalContent/result.dita
+++ b/specification/langRef/technicalContent/result.dita
@@ -16,7 +16,7 @@
         It is defined in the task module.</p>
 </section>
 <section id="attributes"><title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
    </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/technicalContent/revisionid.dita
+++ b/specification/langRef/technicalContent/revisionid.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/revisionid.dita
+++ b/specification/langRef/technicalContent/revisionid.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/sep.dita
+++ b/specification/langRef/technicalContent/sep.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-update-importance"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>sep</xmlelement> element</p>

--- a/specification/langRef/technicalContent/shortcut.dita
+++ b/specification/langRef/technicalContent/shortcut.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/shortcut.dita
+++ b/specification/langRef/technicalContent/shortcut.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/started.dita
+++ b/specification/langRef/technicalContent/started.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/started.dita
+++ b/specification/langRef/technicalContent/started.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/step.dita
+++ b/specification/langRef/technicalContent/step.dita
@@ -16,18 +16,14 @@
 <p>The <xmlelement>step</xmlelement> element is specialized from <xmlelement>li</xmlelement>. It is
         defined in the task module.</p>
 </section>
-<section id="attributes"><title>Attributes</title>
+<section id="attributes">
+      <title>Attributes</title>
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
         /> (with a narrowed definition of <xmlatt>importance</xmlatt>, given below).</p>
-      <dl>
-        <dlentry>
-          <dt>importance</dt>
-          <dd>Specifies whether the step is optional or required. Output processors might highlight
-            steps that are optional or required. Allowed values are <keyword>optional</keyword>,
-              <keyword>required</keyword>, or <xref keyref="attributes-useconreftarget"
-              >-dita-use-conref-target</xref>.</dd>
-        </dlentry>
-      </dl></section>
+      <p>For this element, the <xmlatt>importance</xmlatt> attribute is limited to the values
+          <keyword>optional</keyword>, <keyword>required</keyword>, or <xref
+          keyref="attributes-useconreftarget">-dita-use-conref-target</xref>.</p>
+    </section>
 <example id="example" otherprops="examples">
 <title>Example</title>
    <p>The following code sample shows almost all the elements that <xmlelement>step</xmlelement> can

--- a/specification/langRef/technicalContent/step.dita
+++ b/specification/langRef/technicalContent/step.dita
@@ -18,7 +18,7 @@
 </section>
 <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         /> (with a narrowed definition of <xmlatt>importance</xmlatt>, given below).</p>
       <p>For this element, the <xmlatt>importance</xmlatt> attribute is limited to the values
           <keyword>optional</keyword>, <keyword>required</keyword>, or <xref

--- a/specification/langRef/technicalContent/stepresult.dita
+++ b/specification/langRef/technicalContent/stepresult.dita
@@ -16,7 +16,7 @@
     </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
   </section>
   <example id="example" otherprops="examples">
    <title>Example</title>

--- a/specification/langRef/technicalContent/steps-informal.dita
+++ b/specification/langRef/technicalContent/steps-informal.dita
@@ -19,7 +19,7 @@
 </section>
 <section id="attributes">
 <title>Attributes</title>
-<p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+<p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
 </section>
 <example id="example" otherprops="examples"><title>Example</title>
             <p>An author uses the following markup to provide informal information about how to grow

--- a/specification/langRef/technicalContent/steps-unordered.dita
+++ b/specification/langRef/technicalContent/steps-unordered.dita
@@ -22,7 +22,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
   </section>
   <example id="example" otherprops="examples">
    <title>Example</title>

--- a/specification/langRef/technicalContent/steps.dita
+++ b/specification/langRef/technicalContent/steps.dita
@@ -24,7 +24,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
   </section>
   <example id="example" otherprops="examples">
    <title>Example</title>

--- a/specification/langRef/technicalContent/stepsection.dita
+++ b/specification/langRef/technicalContent/stepsection.dita
@@ -25,7 +25,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/steptroubleshooting.dita
+++ b/specification/langRef/technicalContent/steptroubleshooting.dita
@@ -28,7 +28,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
       
     </section>
 <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/stepxmp.dita
+++ b/specification/langRef/technicalContent/stepxmp.dita
@@ -15,7 +15,7 @@
      <xmlelement>div</xmlelement>. It is defined in the task module.</p>
 </section>
 <section id="attributes"><title>Attributes</title>
-<p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+<p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
 </section>
 <example id="example" otherprops="examples">
 <title>Example</title>

--- a/specification/langRef/technicalContent/summary.dita
+++ b/specification/langRef/technicalContent/summary.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/summary.dita
+++ b/specification/langRef/technicalContent/summary.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/svg-container.dita
+++ b/specification/langRef/technicalContent/svg-container.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -54,7 +54,7 @@
 />, <xref keyref="attributes-common/encoding"><xmlatt>encoding</xmlatt></xref>, <xref
 keyref="attributes-common/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
         "xml"), and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses
-        <xref keyref="attributes-common/linkatts"/>, with narrowed definitions of <xmlatt>href</xmlatt> and
+        <ph conkeyref="attributes-common/ref-linkatts"/>, with narrowed definitions of <xmlatt>href</xmlatt> and
 <xmlatt>format</xmlatt> (given below).</p>
       <dl>
         <dlentry>

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -50,7 +50,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
 />, <xref keyref="attributes-common/encoding"><xmlatt>encoding</xmlatt></xref>, <xref
 keyref="attributes-common/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
         "xml"), and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -53,7 +53,7 @@
       <p>The following attributes are available on this element: <xref keyref="attributes-universal"
 />, <xref keyref="attributes-common/encoding"><xmlatt>encoding</xmlatt></xref>, <xref
 keyref="attributes-common/parse"><xmlatt>parse</xmlatt></xref> (with a default value of
-        "xml"), and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses
+        "xml"), and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>. This element also uses
         <xref keyref="attributes-common/linkatts"/>, with narrowed definitions of <xmlatt>href</xmlatt> and
 <xmlatt>format</xmlatt> (given below).</p>
       <dl>
@@ -65,7 +65,7 @@ keyref="attributes-common/parse"><xmlatt>parse</xmlatt></xref> (with a default v
             specified, where the fragment identifier is the XML ID of the
               <xmlelement>svg</xmlelement> element to be used. This attribute is not required, but
             must be specified if <xmlatt>keyref</xmlatt> is not specified. See <xref
-              keyref="attributes-href"/> for detailed information on supported values and
+              keyref="attributes-common/attr-href"/> for detailed information on supported values and
             processing implications.</dd>
         </dlentry>
         <dlentry>

--- a/specification/langRef/technicalContent/synblk.dita
+++ b/specification/langRef/technicalContent/synblk.dita
@@ -23,7 +23,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/synnoteref.dita
+++ b/specification/langRef/technicalContent/synnoteref.dita
@@ -35,7 +35,7 @@
           <dt><xmlatt>href</xmlatt></dt>
           <dd>A reference to the target syntax note (<xmlelement>synnote</xmlelement>) element. The
             referenced syntax note must be in the same syntax diagram as the
-            <xmlelement>synnoteref</xmlelement> element. See <xref keyref="attributes-href"/> for
+            <xmlelement>synnoteref</xmlelement> element. See <xref keyref="attributes-common/attr-href"/> for
             detailed information on supported values and processing implications.
             <!--For this element, processors should assume the equivalent of <codeph>scope="local"</codeph> and <codeph>format="dita"</codeph>.--></dd>
         </dlentry>

--- a/specification/langRef/technicalContent/synnoteref.dita
+++ b/specification/langRef/technicalContent/synnoteref.dita
@@ -28,7 +28,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         /> and the attribute defined below.</p>
       <dl>
         <dlentry>

--- a/specification/langRef/technicalContent/synph.dita
+++ b/specification/langRef/technicalContent/synph.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/syntaxdiagram.dita
+++ b/specification/langRef/technicalContent/syntaxdiagram.dita
@@ -25,7 +25,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        /> and <xref keyref="attributes-common/displayatts"/>.</p>
+      /> and <ph conkeyref="reuse-attributes/ref-displayatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/syntaxdiagram.dita
+++ b/specification/langRef/technicalContent/syntaxdiagram.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
         /> and <xref keyref="attributes-common/displayatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/systemoutput.dita
+++ b/specification/langRef/technicalContent/systemoutput.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/systemoutput.dita
+++ b/specification/langRef/technicalContent/systemoutput.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/tablelist.dita
+++ b/specification/langRef/technicalContent/tablelist.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/tasktroubleshooting.dita
+++ b/specification/langRef/technicalContent/tasktroubleshooting.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/textentity.dita
+++ b/specification/langRef/technicalContent/textentity.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/textentity.dita
+++ b/specification/langRef/technicalContent/textentity.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/thoroughfare.dita
+++ b/specification/langRef/technicalContent/thoroughfare.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/thoroughfare.dita
+++ b/specification/langRef/technicalContent/thoroughfare.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/toc.dita
+++ b/specification/langRef/technicalContent/toc.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/trademarklist.dita
+++ b/specification/langRef/technicalContent/trademarklist.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/bookmap-booklist-attributes"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/tutorialinfo.dita
+++ b/specification/langRef/technicalContent/tutorialinfo.dita
@@ -15,7 +15,7 @@
           <xmlelement>div</xmlelement>. It is defined in the task module.</p>
 </section>
 <section id="attributes"><title>Attributes</title>
-   <p>The following attributes are available on this element: <xref keyref="attributes-universal"/>.</p>
+   <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>.</p>
    </section>
 <example id="example" otherprops="examples"><title>Example</title><p>The following code sample shows
         how the <xmlelement>tutorialinfo</xmlelement> element might be used in a task topic that is

--- a/specification/langRef/technicalContent/uicontrol.dita
+++ b/specification/langRef/technicalContent/uicontrol.dita
@@ -32,7 +32,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/uicontrol.dita
+++ b/specification/langRef/technicalContent/uicontrol.dita
@@ -32,7 +32,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/userinput.dita
+++ b/specification/langRef/technicalContent/userinput.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/userinput.dita
+++ b/specification/langRef/technicalContent/userinput.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/var.dita
+++ b/specification/langRef/technicalContent/var.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/syntaxelement-update-importance"/></section>
+      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>var</xmlelement> element identifies variables

--- a/specification/langRef/technicalContent/varname.dita
+++ b/specification/langRef/technicalContent/varname.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/varname.dita
+++ b/specification/langRef/technicalContent/varname.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/wintitle.dita
+++ b/specification/langRef/technicalContent/wintitle.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/wintitle.dita
+++ b/specification/langRef/technicalContent/wintitle.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlatt.dita
+++ b/specification/langRef/technicalContent/xmlatt.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlatt.dita
+++ b/specification/langRef/technicalContent/xmlatt.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlelement.dita
+++ b/specification/langRef/technicalContent/xmlelement.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlelement.dita
+++ b/specification/langRef/technicalContent/xmlelement.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlnsname.dita
+++ b/specification/langRef/technicalContent/xmlnsname.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlnsname.dita
+++ b/specification/langRef/technicalContent/xmlnsname.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlpi.dita
+++ b/specification/langRef/technicalContent/xmlpi.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/xmlpi.dita
+++ b/specification/langRef/technicalContent/xmlpi.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/year.dita
+++ b/specification/langRef/technicalContent/year.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/year.dita
+++ b/specification/langRef/technicalContent/year.dita
@@ -20,7 +20,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <xref keyref="attributes-universal"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/> and <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -817,14 +817,6 @@
           <stentry/>
         </strow>
         <strow>
-          <stentry><xmlelement>titlealts</xmlelement></stentry>
-          <stentry>N/A</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry/>
-        </strow>
-        <strow>
           <stentry><xmlelement>tm</xmlelement></stentry>
           <stentry>N/A</stentry>
           <stentry>inline</stentry>

--- a/specification/stubs/KeyStubs.ditamap
+++ b/specification/stubs/KeyStubs.ditamap
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
+  <title>Key definitions for keys that still need to be
+  removed from the 2.0 TC Spec, or key definitions that
+  need to be added to the TC Spec</title>
   <!-- This metadata may no longer be needed, but with baseSpec available we
     can at least reference the appropriate topic rather than a StubTopic. -->
   <!--<keydef keys="conref-about-this-specification" href="StubTopic.dita"></keydef>-->

--- a/specification/stubs/StubTopic.dita
+++ b/specification/stubs/StubTopic.dita
@@ -85,31 +85,7 @@
       <sectiondiv id="author-attributes">
         <p>STUB CONTENT</p>
       </sectiondiv>
-      <sectiondiv id="bookmap-booklist-attributes">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="bookmap-frontbackmatter">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="bookmap-topicrefs">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
       <sectiondiv id="fn-attributes">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="standard-topicmeta-attributes">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="step-and-substep">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="syntaxelement-optreq">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="syntaxelement-update-importance-plus-keyref">
-        <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="syntaxelement-update-importance">
         <p>STUB CONTENT</p>
       </sectiondiv>
       <sectiondiv id="topic-attributes">


### PR DESCRIPTION
Bring TC spec up to date with base spec updates over the last several days:
* Moved attribute topics
* Modified keys for attributes
* Removed common content from base reuse file added to TC reuse file