### PR TITLE
Remove obsolete broken conref

### DIFF
--- a/specification/langRef/technicalContent/bookmap.dita
+++ b/specification/langRef/technicalContent/bookmap.dita
@@ -28,10 +28,6 @@
     <section id="attributes"><title>Attributes</title>
       <p conkeyref="reuse-attributes/map-attributes-common"/>
       <dl>
-        <dlentry conkeyref="reuse-attributes/map-attribute-id">
-          <dt/>
-          <dd/>
-        </dlentry>
         <dlentry conkeyref="reuse-attributes/map-attribute-anchorref">
           <dt/>
           <dd/>


### PR DESCRIPTION
An attribute reuse reference that is no longer needed was still in the file, resulting in a broken reference.