### PR TITLE
Replace sectiondiv with div oasis-tcs/dita#397

### DIFF
--- a/doctypes/dtd/technicalContent/troubleshooting.mod
+++ b/doctypes/dtd/technicalContent/troubleshooting.mod
@@ -55,7 +55,6 @@
                 (%basic.block; |
                  %data.elements.incl; |
                  %foreign.unknown.incl; |
-                 %sectiondiv; |
                  %txt.incl;)*)"
 >
 <!--                    LONG NAME: Troubleshooting                 -->

--- a/doctypes/rng/technicalContent/troubleshootingMod.rng
+++ b/doctypes/rng/technicalContent/troubleshootingMod.rng
@@ -85,7 +85,6 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Troubleshooting//EN"
           <ref name="basic.block"/>
           <ref name="data.elements.incl"/>
           <ref name="foreign.unknown.incl"/>
-          <ref name="sectiondiv"/>
           <ref name="txt.incl"/>
         </choice>
       </zeroOrMore>

--- a/specification/common/conref-tc-attribute.dita
+++ b/specification/common/conref-tc-attribute.dita
@@ -14,7 +14,7 @@
                         </section>
                         <section>
                                 <title>Bookmap related attribute sections</title>
-                                <sectiondiv id="bookmap-booklist-attributes" platform="dita">
+                                <div id="bookmap-booklist-attributes" platform="dita">
                                         <p>The following attributes are available on this element:
                                                 <ph conkeyref="reuse-attributes/ref-universalatts"
                                         />, <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph
@@ -28,14 +28,14 @@
                                         processors can choose to generate an appropriate listing for
                                         this element.
                                         <!--All of the book listings operate in a similar manner; for example, <codeph>&lt;toc href="toc.dita"/&gt;</codeph> references a topic which contains a manual table of contents, while <codeph>&lt;toc/&gt;</codeph> indicates that a processor should generate the table of contents. --></p>
-                                </sectiondiv><sectiondiv id="bookmap-topicrefs" platform="dita">
+                                </div><div id="bookmap-topicrefs" platform="dita">
                                         <p>The following attributes are available on this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"/>,
                                                 <ph conkeyref="reuse-attributes/ref-linkatts"/>, <ph
                                                         conkeyref="reuse-attributes/ref-commonmapatts"/>,
                                                 and <xref keyref="attributes-common/attr-keyref"
                                                         ><xmlatt>keyref</xmlatt></xref>.</p>
-                                </sectiondiv><sectiondiv id="bookmap-frontbackmatter" platform="dita">
+                                </div><div id="bookmap-frontbackmatter" platform="dita">
                                         <p>The following attributes are available on this element:
                                                 <ph conkeyref="reuse-attributes/ref-universalatts"
                                         />, <ph conkeyref="reuse-attributes/ref-commonmapatts"/>,
@@ -47,7 +47,7 @@
                                                   ><xmlatt>scope</xmlatt></xref>, and <xref
                                                 keyref="attributes-common/attr-type"
                                                   ><xmlatt>type</xmlatt></xref>.</p>
-                                </sectiondiv>
+                                </div>
                         </section>
                         <section id="section-2"><title>Reusable groups for syntax diagram elements</title><p>These tend to
                                 be similar, with tweaks in <xmlatt>importance</xmlatt>, or adding/removing <xref
@@ -55,7 +55,7 @@
                                         ><xmlatt>keyref</xmlatt></xref>.</p><p><keyword>optreq-sectiondiv</keyword> is used by <xmlelement>delim</xmlelement>,
                                                 <xmlelement>repsep</xmlelement>. The
                                                 <xmlatt>importance</xmlatt> definition inside is also used
-                                                by <xmlelement>fragref</xmlelement>.</p><sectiondiv
+                                                by <xmlelement>fragref</xmlelement>.</p><div
                                                         id="syntaxelement-optreq">
                                                         <p>The following attributes are available on this element: <ph
                                                                 conkeyref="reuse-attributes/ref-universalatts"/>
@@ -68,7 +68,7 @@
                                                 <keyword>optional</keyword>,
                                                 <keyword>required</keyword>, or
                                                 <keyword>-dita-use-conref-target</keyword>.</p>
-                                                </sectiondiv><sectiondiv id="syntaxelement-update-importance">
+                                                </div><div id="syntaxelement-update-importance">
                                                         <p>The following attributes are available on
                                         this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"
@@ -81,7 +81,7 @@
                                                 <keyword>required</keyword>,
                                                 <keyword>default</keyword>, or
                                                 <keyword>-dita-use-conref-target</keyword>.</p>
-                                                </sectiondiv><sectiondiv id="syntaxelement-update-importance-plus-keyref">
+                                                </div><div id="syntaxelement-update-importance-plus-keyref">
                                                         <p>The following attributes are available on
                                         this element: <ph
                                                 conkeyref="reuse-attributes/ref-universalatts"/> and
@@ -95,6 +95,6 @@
                                                 <keyword>required</keyword>,
                                                 <keyword>default</keyword>, or
                                                 <keyword>-dita-use-conref-target</keyword>.</p>
-                                                </sectiondiv></section>
+                                                </div></section>
                 </conbody>
         </concept>

--- a/specification/langRef/technicalContent/abbrevlist.dita
+++ b/specification/langRef/technicalContent/abbrevlist.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock xml:space="preserve">&lt;abbrevlist href="abbrev.dita"/&gt;</codeblock></example>

--- a/specification/langRef/technicalContent/amendments.dita
+++ b/specification/langRef/technicalContent/amendments.dita
@@ -22,7 +22,7 @@
     hierarchy</title>
       <p>The <xmlelement>amendments</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-  <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+  <section id="attributes"><title>Attributes</title><div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
   <example id="example" otherprops="examples"><title>Example</title>
       <p>The following code sample specifies that a change history list is generated in the
         publication front matter. The content of the change history list is contained in the DITA

--- a/specification/langRef/technicalContent/appendices.dita
+++ b/specification/langRef/technicalContent/appendices.dita
@@ -20,7 +20,7 @@
         ><title>Specialization hierarchy</title>
       <p>The <xmlelement>appendices</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-    <section id="attributes"><title>Attributes</title><sectiondiv
+    <section id="attributes"><title>Attributes</title><div
         conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock>&lt;appendices toc="yes" deliveryTarget="html">

--- a/specification/langRef/technicalContent/appendix.dita
+++ b/specification/langRef/technicalContent/appendix.dita
@@ -20,7 +20,7 @@
         ><title>Specialization hierarchy</title>
       <p>The <xmlelement>appendix</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-    <section id="attributes"><title>Attributes</title><sectiondiv
+    <section id="attributes"><title>Attributes</title><div
         conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples"><title>Example</title><p>Appendix topics that
         include

--- a/specification/langRef/technicalContent/authorinformation.dita
+++ b/specification/langRef/technicalContent/authorinformation.dita
@@ -19,7 +19,7 @@
         ><title>Specialization hierarchy</title>
       <p>The <xmlelement>authorinformation</xmlelement> element is specialized from
           <xmlelement>author</xmlelement>. It is defined in the XNAL domain module.</p></section>
-    <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-attributes/author-attributes"/></section>
+    <section id="attributes"><title>Attributes</title><div conkeyref="reuse-attributes/author-attributes"/></section>
     <example id="example" otherprops="examples"
       ><title>Example</title>
       <p>In the following code sample, the <xmlelement>authorinformation</xmlelement> element is

--- a/specification/langRef/technicalContent/backmatter.dita
+++ b/specification/langRef/technicalContent/backmatter.dita
@@ -20,7 +20,7 @@
    <p>The <xmlelement>backmatter</xmlelement> element is specialized from
      <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p>
   </section>
-  <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-tc-attributes/bookmap-frontbackmatter"/></section>
+  <section id="attributes"><title>Attributes</title><div conkeyref="reuse-tc-attributes/bookmap-frontbackmatter"/></section>
   <example id="example" otherprops="examples">
    <title>Example</title>
    <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/bibliolist.dita
+++ b/specification/langRef/technicalContent/bibliolist.dita
@@ -26,7 +26,7 @@
         ><title>Specialization hierarchy</title>
       <p>The <xmlelement>bibliolist</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-    <section id="attributes"><title>Attributes</title><sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
+    <section id="attributes"><title>Attributes</title><div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock>&lt;bookmap>
   &lt;!-- ... -->

--- a/specification/langRef/technicalContent/bookabstract.dita
+++ b/specification/langRef/technicalContent/bookabstract.dita
@@ -23,7 +23,7 @@
     hierarchy</title>
       <p>The <xmlelement>bookabstract</xmlelement> element is specialized from
           <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-  <section id="attributes"><title>Attributes</title><sectiondiv
+  <section id="attributes"><title>Attributes</title><div
     conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
   <example id="example" otherprops="examples"><title>Example</title><p>See the example in <xref
      href="bookmap.dita"/>.</p></example>

--- a/specification/langRef/technicalContent/booklist.dita
+++ b/specification/langRef/technicalContent/booklist.dita
@@ -27,7 +27,7 @@
                 ><title>Specialization hierarchy</title>
             <p>The <xmlelement>booklist</xmlelement> element is specialized from
                     <xmlelement>topicref</xmlelement>. It is defined in the bookmap module.</p></section>
-        <section id="attributes"><title>Attributes</title><sectiondiv
+        <section id="attributes"><title>Attributes</title><div
                 conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
         <example id="example" otherprops="examples"><title>Example</title><p>In this case the
                     <xmlelement>booklist</xmlelement> element references a topic that contains a

--- a/specification/langRef/technicalContent/chapter.dita
+++ b/specification/langRef/technicalContent/chapter.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>Chapter topics that include

--- a/specification/langRef/technicalContent/colophon.dita
+++ b/specification/langRef/technicalContent/colophon.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;bookmap>

--- a/specification/langRef/technicalContent/concept.dita
+++ b/specification/langRef/technicalContent/concept.dita
@@ -29,7 +29,7 @@
           <xmlelement>topic</xmlelement>. It is defined in the concept module.</p>
     </section>
     <section id="attributes">
-      <title>Attributes</title><sectiondiv
+      <title>Attributes</title><div
         conkeyref="reuse-attributes/topic-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title><draft-comment author="BobThomas">This ought to be an example of a

--- a/specification/langRef/technicalContent/dedication.dita
+++ b/specification/langRef/technicalContent/dedication.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;frontmatter>

--- a/specification/langRef/technicalContent/delim.dita
+++ b/specification/langRef/technicalContent/delim.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-optreq"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-optreq"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>delim</xmlelement> element specifies that the

--- a/specification/langRef/technicalContent/draftintro.dita
+++ b/specification/langRef/technicalContent/draftintro.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;frontmatter>

--- a/specification/langRef/technicalContent/figurelist.dita
+++ b/specification/langRef/technicalContent/figurelist.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/frontmatter.dita
+++ b/specification/langRef/technicalContent/frontmatter.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-frontbackmatter"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-frontbackmatter"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/glossarylist.dita
+++ b/specification/langRef/technicalContent/glossarylist.dita
@@ -25,7 +25,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/>
+      <div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/glossentry.dita
+++ b/specification/langRef/technicalContent/glossentry.dita
@@ -37,7 +37,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/topic-attributes"/>
+      <div conkeyref="reuse-attributes/topic-attributes"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/glossgroup.dita
+++ b/specification/langRef/technicalContent/glossgroup.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/topic-attributes"/>
+      <div conkeyref="reuse-attributes/topic-attributes"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/groupchoice.dita
+++ b/specification/langRef/technicalContent/groupchoice.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the diagram presents a choice of two alternate ways to

--- a/specification/langRef/technicalContent/groupcomp.dita
+++ b/specification/langRef/technicalContent/groupcomp.dita
@@ -32,7 +32,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, two composite groups represent two alternate ways to specify

--- a/specification/langRef/technicalContent/groupseq.dita
+++ b/specification/langRef/technicalContent/groupseq.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, a short set of command line syntax is specified in a

--- a/specification/langRef/technicalContent/indexlist.dita
+++ b/specification/langRef/technicalContent/indexlist.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/kwd.dita
+++ b/specification/langRef/technicalContent/kwd.dita
@@ -30,7 +30,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance-plus-keyref"
+      <div conkeyref="reuse-tc-attributes/syntaxelement-update-importance-plus-keyref"
       /></section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/notices.dita
+++ b/specification/langRef/technicalContent/notices.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>This example references a notices topic that contains legal content.</p>

--- a/specification/langRef/technicalContent/oper.dita
+++ b/specification/langRef/technicalContent/oper.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>oper</xmlelement> element specifies that the

--- a/specification/langRef/technicalContent/part.dita
+++ b/specification/langRef/technicalContent/part.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>Part topics that include chapters and

--- a/specification/langRef/technicalContent/preface.dita
+++ b/specification/langRef/technicalContent/preface.dita
@@ -21,7 +21,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-topicrefs"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/reference.dita
+++ b/specification/langRef/technicalContent/reference.dita
@@ -31,7 +31,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/topic-attributes"/>
+      <div conkeyref="reuse-attributes/topic-attributes"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/repsep.dita
+++ b/specification/langRef/technicalContent/repsep.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-optreq"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-optreq"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample example, a file listing can be requested for multiple volumes.

--- a/specification/langRef/technicalContent/sep.dita
+++ b/specification/langRef/technicalContent/sep.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>sep</xmlelement> element is used to separate

--- a/specification/langRef/technicalContent/synnote.dita
+++ b/specification/langRef/technicalContent/synnote.dita
@@ -35,7 +35,7 @@ itself.</p>
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/fn-attributes"/></section>
+      <div conkeyref="reuse-attributes/fn-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, a syntax note reminds the reader where to find information

--- a/specification/langRef/technicalContent/tablelist.dita
+++ b/specification/langRef/technicalContent/tablelist.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/task.dita
+++ b/specification/langRef/technicalContent/task.dita
@@ -37,7 +37,7 @@
   </section>
   <section id="attributes">
    <title>Attributes</title>
-   <sectiondiv conkeyref="reuse-attributes/topic-attributes"/>
+   <div conkeyref="reuse-attributes/topic-attributes"/>
   </section>
   <example id="example" otherprops="examples">
    <title>Example</title>

--- a/specification/langRef/technicalContent/toc.dita
+++ b/specification/langRef/technicalContent/toc.dita
@@ -29,7 +29,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/trademarklist.dita
+++ b/specification/langRef/technicalContent/trademarklist.dita
@@ -26,7 +26,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
+      <div conkeyref="reuse-tc-attributes/bookmap-booklist-attributes"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>See the example in <xref href="bookmap.dita"/>.</p>

--- a/specification/langRef/technicalContent/troubleshooting.dita
+++ b/specification/langRef/technicalContent/troubleshooting.dita
@@ -33,7 +33,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-attributes/topic-attributes"/>
+      <div conkeyref="reuse-attributes/topic-attributes"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/var.dita
+++ b/specification/langRef/technicalContent/var.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <sectiondiv conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
+      <div conkeyref="reuse-tc-attributes/syntaxelement-update-importance"/></section>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, the <xmlelement>var</xmlelement> element identifies variables

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -673,14 +673,6 @@
           <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
         </strow>
         <strow>
-          <stentry><xmlelement>sectiondiv</xmlelement></stentry>
-          <stentry>N/A</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry/>
-        </strow>
-        <strow>
           <stentry><xmlelement>series</xmlelement></stentry>
           <stentry>N/A</stentry>
           <stentry>block (metadata)</stentry>

--- a/specification/stubs/StubTopic.dita
+++ b/specification/stubs/StubTopic.dita
@@ -78,15 +78,15 @@
       <p><xref id="outputclass" href="#topic_m1s_s5j_c2b/stub-section"></xref></p>
       <p><xref id="spectitle" href="#topic_m1s_s5j_c2b/stub-section"></xref></p>
       <codeblock id="concept-codeblock">STUB CONTENT</codeblock>
-      <sectiondiv id="author-attributes">
+      <div id="author-attributes">
         <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="fn-attributes">
+      </div>
+      <div id="fn-attributes">
         <p>STUB CONTENT</p>
-      </sectiondiv>
-      <sectiondiv id="topic-attributes">
+      </div>
+      <div id="topic-attributes">
         <p>STUB CONTENT</p>
-      </sectiondiv>
+      </div>
     </section>
     <section id="dita-written-specification"><title>STUB CONTENT</title></section>
     <section id="stub-section"><title>STUB CONTENT</title></section>


### PR DESCRIPTION
* Updates base spec to version that removed `sectiondiv`
* Replace tech-comm use of `<sectiondiv>` with `<div>`
* Remove `sectiondiv` from the appendix with element translation guidelines
* Remove explicit reference to `sectiondiv` in troubleshooting grammar