### PR TITLE
Fix RNG references to alt titles domain

### DIFF
--- a/doctypes/rng/bookmap/bookmap.rng
+++ b/doctypes/rng/bookmap/bookmap.rng
@@ -84,7 +84,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 BookMap//EN"
      <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
      <include href="bookmapMod.rng"/>
      <include href="../technicalContent/abbreviateDomain.rng"/>
-     <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+     <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
      <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
      <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/classificationMap/classifyMap.rng
+++ b/doctypes/rng/classificationMap/classifyMap.rng
@@ -80,7 +80,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Classification Map//EN"
   
       <include href="urn:oasis:names:tc:dita:spec:classification:rng:classifyDomain.rng:2.0"/>
       <include href="../technicalContent/abbreviateDomain.rng"/>
-      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/concept.rng
+++ b/doctypes/rng/technicalContent/concept.rng
@@ -85,7 +85,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Concept//EN"
       </define>
     </include>
     <include href="abbreviateDomain.rng"/>
-    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/ditabase.rng
+++ b/doctypes/rng/technicalContent/ditabase.rng
@@ -102,7 +102,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Composite//EN"
       <include href="troubleshootingMod.rng"/>
     
       <include href="abbreviateDomain.rng"/>
-      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/generalTask.rng
+++ b/doctypes/rng/technicalContent/generalTask.rng
@@ -85,7 +85,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 General Task//EN"
       </define>
     </include>
     <include href="abbreviateDomain.rng"/>
-    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/glossentry.rng
+++ b/doctypes/rng/technicalContent/glossentry.rng
@@ -84,7 +84,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Glossary Entry//EN"
           <empty/>
         </define>
       </include>
-      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/glossgroup.rng
+++ b/doctypes/rng/technicalContent/glossgroup.rng
@@ -77,7 +77,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.x Glossary Group//EN"
     <include href="conceptMod.rng"/>
     <include href="glossentryMod.rng"/>
     <include href="glossgroupMod.rng"/>
-    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/map.rng
+++ b/doctypes/rng/technicalContent/map.rng
@@ -84,7 +84,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Map//EN"
       <include href="urn:oasis:names:tc:dita:rng:mapGroupMod.rng:2.0"/>
 
       <include href="abbreviateDomain.rng"/>
-      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/reference.rng
+++ b/doctypes/rng/technicalContent/reference.rng
@@ -85,7 +85,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Reference//EN"
       </define>
     </include>
     <include href="abbreviateDomain.rng"/>
-    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/task.rng
+++ b/doctypes/rng/technicalContent/task.rng
@@ -91,7 +91,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Task//EN"
       <a:documentation> MODULE INCLUSIONS </a:documentation>
       <include href="urn:oasis:names:tc:dita:rng:topicMod.rng:2.0"/>
       <include href="abbreviateDomain.rng"/>
-      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/topic.rng
+++ b/doctypes/rng/technicalContent/topic.rng
@@ -84,7 +84,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Topic//EN"
       </define>
     </include>  
     <include href="abbreviateDomain.rng"/>
-    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+    <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
     <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
     <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>

--- a/doctypes/rng/technicalContent/troubleshooting.rng
+++ b/doctypes/rng/technicalContent/troubleshooting.rng
@@ -90,7 +90,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Troubleshooting//EN"
          </define>
       </include>
       <include href="abbreviateDomain.rng"/>
-      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng" dita:since="2.0"/>
+      <include href="urn:oasis:names:tc:dita:rng:alternativeTitlesDomain.rng:2.0" dita:since="2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:audienceAttDomain.rng:2.0"/>
       <include href="urn:oasis:names:tc:dita:rng:deliveryTargetAttDomain.rng:2.0" dita:since="1.3"/>
       <include href="urn:oasis:names:tc:dita:rng:platformAttDomain.rng:2.0"/>


### PR DESCRIPTION
Noticed in build tests that bookmap was failing to process with the RNG, and traced it to the alternative titles domain, which was added without the required `:2.0` at the end of the reference.