### PR TITLE
Add keyref to xml, markup elements oasis-tcs/dita#397

### DIFF
--- a/doctypes/dtd/technicalContent/markupDomain.mod
+++ b/doctypes/dtd/technicalContent/markupDomain.mod
@@ -28,7 +28,10 @@
                          %text;)*"
 >
 <!ENTITY % markupname.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  markupname %markupname.content;>
 <!ATTLIST  markupname %markupname.attributes;>

--- a/doctypes/dtd/technicalContent/xmlDomain.mod
+++ b/doctypes/dtd/technicalContent/xmlDomain.mod
@@ -35,7 +35,10 @@
                          %text;)*"
 >
 <!ENTITY % numcharref.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  numcharref %numcharref.content;>
 <!ATTLIST  numcharref %numcharref.attributes;>
@@ -49,7 +52,10 @@
                          %text;)*"
 >
 <!ENTITY % parameterentity.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  parameterentity %parameterentity.content;>
 <!ATTLIST  parameterentity %parameterentity.attributes;>
@@ -63,7 +69,10 @@
                          %text;)*"
 >
 <!ENTITY % textentity.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  textentity %textentity.content;>
 <!ATTLIST  textentity %textentity.attributes;>
@@ -77,7 +86,10 @@
                          %text;)*"
 >
 <!ENTITY % xmlatt.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  xmlatt %xmlatt.content;>
 <!ATTLIST  xmlatt %xmlatt.attributes;>
@@ -91,7 +103,10 @@
                          %text;)*"
 >
 <!ENTITY % xmlelement.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  xmlelement %xmlelement.content;>
 <!ATTLIST  xmlelement %xmlelement.attributes;>
@@ -105,7 +120,10 @@
                          %text;)*"
 >
 <!ENTITY % xmlnsname.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  xmlnsname %xmlnsname.content;>
 <!ATTLIST  xmlnsname %xmlnsname.attributes;>
@@ -119,7 +137,10 @@
                          %text;)*"
 >
 <!ENTITY % xmlpi.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  xmlpi %xmlpi.content;>
 <!ATTLIST  xmlpi %xmlpi.attributes;>

--- a/doctypes/rng/technicalContent/markupDomain.rng
+++ b/doctypes/rng/technicalContent/markupDomain.rng
@@ -62,6 +62,9 @@
         </zeroOrMore>
       </define>
       <define name="markupname.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="markupname.element">

--- a/doctypes/rng/technicalContent/xmlDomain.rng
+++ b/doctypes/rng/technicalContent/xmlDomain.rng
@@ -60,6 +60,9 @@
         </zeroOrMore>
       </define>
       <define name="numcharref.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="numcharref.element">
@@ -85,6 +88,9 @@
         </zeroOrMore>
       </define>
       <define name="parameterentity.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="parameterentity.element">
@@ -111,6 +117,9 @@
         </zeroOrMore>
       </define>
       <define name="textentity.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="textentity.element">
@@ -138,6 +147,9 @@
         </zeroOrMore>
       </define>
       <define name="xmlatt.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="xmlatt.element">
@@ -164,6 +176,9 @@
         </zeroOrMore>
       </define>
       <define name="xmlelement.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="xmlelement.element">
@@ -190,6 +205,9 @@
         </zeroOrMore>
       </define>
       <define name="xmlnsname.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="xmlnsname.element">
@@ -217,6 +235,9 @@
         </zeroOrMore>
       </define>
       <define name="xmlpi.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="xmlpi.element">


### PR DESCRIPTION
Per today's TC, add keyref to markup and xml mention domain specializations of `ph` to match the text of the spec.

Also brings base spec up to date for related changes in highlight domain.