### PR TITLE
Remove obsolete markup

### DIFF
--- a/specification/langRef/technicalContent/bookmap.dita
+++ b/specification/langRef/technicalContent/bookmap.dita
@@ -27,12 +27,6 @@
           <xmlelement>map</xmlelement>. It is defined in the bookmap module.</p></section>
     <section id="attributes"><title>Attributes</title>
       <p conkeyref="reuse-attributes/map-attributes-common"/>
-      <dl>
-        <dlentry conkeyref="reuse-attributes/map-attribute-anchorref">
-          <dt/>
-          <dd/>
-        </dlentry>
-      </dl>
     </section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock>&lt;bookmap xml:lang="en-us">

--- a/specification/langRef/technicalContent/cause.dita
+++ b/specification/langRef/technicalContent/cause.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conkeyref="reuse-attributes/universal-spectitle"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/chdesc.dita
+++ b/specification/langRef/technicalContent/chdesc.dita
@@ -22,9 +22,8 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        />, <xref keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the attributes defined
-        below.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/tablescope">
           <dt/>

--- a/specification/langRef/technicalContent/chdeschd.dita
+++ b/specification/langRef/technicalContent/chdeschd.dita
@@ -18,9 +18,8 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-        />, <xref keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the attributes defined
-        below.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/tablescope">
           <dt/>

--- a/specification/langRef/technicalContent/choicetable.dita
+++ b/specification/langRef/technicalContent/choicetable.dita
@@ -33,9 +33,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          keyref="reuse-attributes/ref-displayatts"/>, <ph
-          conkeyref="reuse-attributes/ref-simpletableatts"/>, and <xref
-          keyref="attributes-common/attr-spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
+          keyref="reuse-attributes/ref-displayatts"/>, and <ph
+          conkeyref="reuse-attributes/ref-simpletableatts"/>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>keycol</xmlatt> attribute has a default
         value of <keyword>1</keyword>.</p>
     </section>

--- a/specification/langRef/technicalContent/choption.dita
+++ b/specification/langRef/technicalContent/choption.dita
@@ -13,9 +13,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the
-        attributes defined below.</p>
+          conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/tablescope">
           <dt/>

--- a/specification/langRef/technicalContent/choptionhd.dita
+++ b/specification/langRef/technicalContent/choptionhd.dita
@@ -20,9 +20,8 @@
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <ph
-               conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-               keyref="attributes-common/attr-specentry"><xmlatt>specentry</xmlatt></xref>, and the
-            attributes defined below.</p>
+               conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined
+            below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/tablescope">
                <dt/>

--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -29,9 +29,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          keyref="reuse-attributes/ref-displayatts"/>, <xref keyref="attributes-common/xmlspace"
-            ><xmlatt>xml:space</xmlatt></xref>, and <xref keyref="attributes-common/attr-spectitle"
-            ><xmlatt>spectitle</xmlatt></xref>.</p>
+          keyref="reuse-attributes/ref-displayatts"/>, and <xref keyref="attributes-common/xmlspace"
+            ><xmlatt>xml:space</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/condition.dita
+++ b/specification/langRef/technicalContent/condition.dita
@@ -28,7 +28,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conkeyref="reuse-attributes/universal-spectitle"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/diagnostics-general.dita
+++ b/specification/langRef/technicalContent/diagnostics-general.dita
@@ -30,7 +30,7 @@
         </section>
         <section>
             <title>Attributes</title>
-            <p conkeyref="reuse-attributes/universal-spectitle"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
         </section>
         <example otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/technicalContent/diagnostics-steps.dita
+++ b/specification/langRef/technicalContent/diagnostics-steps.dita
@@ -30,7 +30,7 @@
         </section>
         <section id="section_vp4_2kf_knb">
             <title>Attributes</title>
-            <p conkeyref="reuse-attributes/universal-spectitle"/>
+            <p conkeyref="reuse-attributes/only-universal"/>
         </section>
         <example otherprops="examples">
             <title>Example</title>

--- a/specification/langRef/technicalContent/equation-figure.dita
+++ b/specification/langRef/technicalContent/equation-figure.dita
@@ -57,9 +57,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-        conkeyref="reuse-attributes/ref-displayatts"/>, and <xref
-                                        keyref="attributes-common/attr-spectitle"><xmlatt>spectitle</xmlatt></xref>.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and  <ph
+          conkeyref="reuse-attributes/ref-displayatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/msgblock.dita
+++ b/specification/langRef/technicalContent/msgblock.dita
@@ -36,9 +36,8 @@
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
           conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-displayatts"/>, <xref keyref="attributes-common/xmlspace"
-            ><xmlatt>xml:space</xmlatt></xref>, and <xref keyref="attributes-common/attr-spectitle"
-            ><xmlatt>spectitle</xmlatt></xref>.</p>
+          conkeyref="reuse-attributes/ref-displayatts"/>, and  <xref
+          keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/parml.dita
+++ b/specification/langRef/technicalContent/parml.dita
@@ -25,7 +25,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conkeyref="reuse-attributes/universal-spectitle-compact"/>
+      <p conkeyref="reuse-attributes/universal-compact"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/propdesc.dita
+++ b/specification/langRef/technicalContent/propdesc.dita
@@ -20,9 +20,8 @@ values.</shortdesc>
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <ph
-               conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-               keyref="attributes-common/specentry"><xmlatt>specentry</xmlatt></xref>, and the
-            attributes defined below.</p>
+               conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined
+            below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/stentry-rowspan">
                <dt/>

--- a/specification/langRef/technicalContent/propdeschd.dita
+++ b/specification/langRef/technicalContent/propdeschd.dita
@@ -25,9 +25,7 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-common/specentry"><xmlatt>specentry</xmlatt></xref>, and the attributes
-        defined below.</p>
+          conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/tablescope">
           <dt/>

--- a/specification/langRef/technicalContent/proptype.dita
+++ b/specification/langRef/technicalContent/proptype.dita
@@ -18,9 +18,8 @@
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <ph
-               conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-               keyref="attributes-common/specentry"><xmlatt>specentry</xmlatt></xref>, and the
-            attributes defined below.</p>
+               conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined
+            below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/stentry-rowspan">
                <dt/>

--- a/specification/langRef/technicalContent/proptypehd.dita
+++ b/specification/langRef/technicalContent/proptypehd.dita
@@ -21,9 +21,8 @@ type column of a properties table.</shortdesc>
             <section id="attributes">
                   <title>Attributes</title>
                   <p>The following attributes are available on this element: <ph
-                              conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-                              keyref="attributes-common/specentry"
-                        ><xmlatt>specentry</xmlatt></xref>, and the attributes defined below.</p>
+                              conkeyref="reuse-attributes/ref-universalatts"/> and the attributes
+                        defined below.</p>
                   <dl>
                         <dlentry conkeyref="reuse-attributes/tablescope">
                               <dt/>

--- a/specification/langRef/technicalContent/propvalue.dita
+++ b/specification/langRef/technicalContent/propvalue.dita
@@ -27,9 +27,8 @@
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <ph
-               conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-               keyref="attributes-common/specentry"><xmlatt>specentry</xmlatt></xref>, and the
-            attributes defined below.</p>
+               conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined
+            below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/stentry-rowspan">
                <dt/>

--- a/specification/langRef/technicalContent/propvaluehd.dita
+++ b/specification/langRef/technicalContent/propvaluehd.dita
@@ -20,9 +20,8 @@ value column of a properties table.</shortdesc>
       <section id="attributes">
          <title>Attributes</title>
          <p>The following attributes are available on this element: <ph
-               conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-               keyref="attributes-common/specentry"><xmlatt>specentry</xmlatt></xref>, and the
-            attributes defined below.</p>
+               conkeyref="reuse-attributes/ref-universalatts"/> and the attributes defined
+            below.</p>
          <dl>
             <dlentry conkeyref="reuse-attributes/tablescope">
                <dt/>

--- a/specification/langRef/technicalContent/refsyn.dita
+++ b/specification/langRef/technicalContent/refsyn.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conkeyref="reuse-attributes/universal-spectitle"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/remedy.dita
+++ b/specification/langRef/technicalContent/remedy.dita
@@ -27,7 +27,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p conkeyref="reuse-attributes/universal-spectitle"/>
+      <p conkeyref="reuse-attributes/only-universal"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -3834,60 +3834,6 @@
           <stentry>no</stentry>
         </strow>
         <strow>
-          <stentry><xmlelement>hasInstance</xmlelement></stentry>
-          <stentry><xmlelement>topicref</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry>no</stentry>
-        </strow>
-        <strow>
-          <stentry><xmlelement>hasKind</xmlelement></stentry>
-          <stentry><xmlelement>topicref</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry>no</stentry>
-        </strow>
-        <strow>
-          <stentry><xmlelement>hasNarrower</xmlelement></stentry>
-          <stentry><xmlelement>topicref</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry>no</stentry>
-        </strow>
-        <strow>
-          <stentry><xmlelement>hasPart</xmlelement></stentry>
-          <stentry><xmlelement>topicref</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry>no</stentry>
-        </strow>
-        <strow>
-          <stentry><xmlelement>hasRelated</xmlelement></stentry>
-          <stentry><xmlelement>topicref</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry>no</stentry>
-        </strow>
-        <strow>
-          <stentry><xmlelement>relatedSubjects</xmlelement></stentry>
-          <stentry><xmlelement>topicref</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry>no</stentry>
-        </strow>
-        <strow>
           <stentry><xmlelement>subjectdef</xmlelement></stentry>
           <stentry><xmlelement>topicref</xmlelement></stentry>
           <stentry>yes</stentry>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -3870,42 +3870,6 @@
           <stentry>no</stentry>
         </strow>
         <strow>
-          <stentry><xmlelement>subjectRel</xmlelement></stentry>
-          <stentry><xmlelement>relrow</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry/>
-        </strow>
-        <strow>
-          <stentry><xmlelement>subjectRelHeader</xmlelement></stentry>
-          <stentry><xmlelement>relrow</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry/>
-        </strow>
-        <strow>
-          <stentry><xmlelement>subjectRelTable</xmlelement></stentry>
-          <stentry><xmlelement>reltable</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry/>
-        </strow>
-        <strow>
-          <stentry><xmlelement>subjectRole</xmlelement></stentry>
-          <stentry><xmlelement>relcell</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry/>
-        </strow>
-        <strow>
           <stentry><xmlelement>subjectScheme</xmlelement></stentry>
           <stentry><xmlelement>map</xmlelement></stentry>
           <stentry>yes</stentry>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -41,12 +41,7 @@
         <li>For all elements, the <xmlatt>translate</xmlatt> attribute will override the suggested default
           translation setting. So, a translation setting of "yes" or "no" in the table below does
           not guarantee that an element will always, or never, be translated.</li>
-        <li>If an element has translatable attributes, they are listed in the last column. Note that
-          the <xmlatt>spectitle</xmlatt>  attribute is described with a footnote. <fn id="spectitle"
-            >The <xmlatt>spectitle</xmlatt> attribute can contain translatable text. The direct use
-            of fixed-in-the-DTD text by tools is discouraged, in favor of using the value as a
-            lookup string to find the translation outside of the file, using accepted localization
-            methods for generated text. </fn></li>
+        <li>If an element has translatable attributes, they are listed in the last column.</li>
         <li>The <xmlelement>keyword</xmlelement> element (as well as specializations of
             <xmlelement>keyword</xmlelement>) is an inline, phrase-like element when it appears in
           the body of a document. It <ph >can</ph> also appear in the
@@ -252,7 +247,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>dlentry</xmlelement></stentry>
@@ -308,7 +303,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>featnum</xmlelement></stentry>
@@ -324,7 +319,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>figgroup</xmlelement></stentry>
@@ -413,7 +408,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>link</xmlelement></stentry>
@@ -437,7 +432,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>linkpool</xmlelement></stentry>
@@ -493,7 +488,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>othertype</xmlatt>, <xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry><xmlatt>othertype</xmlatt></stentry>
         </strow>
         <strow>
           <stentry><xmlelement>object</xmlelement> <!--<xref href='"#elements/foreign1"' type="fn"></xref>--></stentry>
@@ -509,7 +504,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>othermeta</xmlelement></stentry>
@@ -565,7 +560,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>prodinfo</xmlelement></stentry>
@@ -669,7 +664,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>series</xmlelement></stentry>
@@ -693,7 +688,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>sl</xmlelement></stentry>
@@ -701,7 +696,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>sli</xmlelement></stentry>
@@ -829,7 +824,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>unknown</xmlelement></stentry>
@@ -1616,7 +1611,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>glossAlternateFor</xmlelement></stentry>
@@ -1742,7 +1737,8 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>othertype</xmlatt> <i>(removes <xmlatt>spectitle</xmlatt>)</i></stentry>
+          <stentry><xmlatt>othertype</xmlatt>
+          </stentry>
         </strow>
       </simpletable>
     </section>
@@ -1783,7 +1779,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>property</xmlelement></stentry>
@@ -1873,7 +1869,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
       </simpletable>
     </section>
@@ -1932,7 +1928,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>choicetable</xmlelement></stentry>
@@ -1941,7 +1937,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>choption</xmlelement></stentry>
@@ -1986,7 +1982,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>info</xmlelement></stentry>
@@ -2004,7 +2000,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>prereq</xmlelement></stentry>
@@ -2013,7 +2009,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>result</xmlelement></stentry>
@@ -2022,7 +2018,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>step</xmlelement></stentry>
@@ -2049,7 +2045,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>steps-informal</xmlelement></stentry>
@@ -2058,7 +2054,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>steps-unordered</xmlelement></stentry>
@@ -2067,7 +2063,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>stepsection</xmlelement></stentry>
@@ -2121,7 +2117,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>tutorialinfo</xmlelement></stentry>
@@ -2399,8 +2395,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle"
-              type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>codeph</xmlelement></stentry>
@@ -2436,8 +2431,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle"
-              type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>parmname</xmlelement></stentry>
@@ -2514,7 +2508,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>msgnum</xmlelement></stentry>
@@ -2708,7 +2702,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><i>removes <xmlatt>spectitle</xmlatt></i></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>var</xmlelement></stentry>
@@ -2749,7 +2743,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>shortcut</xmlelement></stentry>
@@ -2817,7 +2811,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes (can contain translatable alternate text)</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>shape</xmlelement></stentry>
@@ -3262,7 +3256,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>othertype</xmlatt>, <xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry><xmlatt>othertype</xmlatt></stentry>
         </strow>
         <strow>
           <stentry><xmlelement>hazardsymbol</xmlelement></stentry>
@@ -3289,7 +3283,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>spectitle</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>typeofhazard</xmlelement></stentry>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -878,14 +878,6 @@
           <stentry>Translatable attributes?</stentry>
         </sthead>
         <strow>
-          <stentry><xmlelement>anchor</xmlelement></stentry>
-          <stentry>N/A</stentry>
-          <stentry>n/a</stentry>
-          <stentry>n/a</stentry>
-          <stentry>n/a</stentry>
-          <stentry/>
-        </strow>
-        <strow>
           <stentry><xmlelement>linktext</xmlelement></stentry>
           <stentry>N/A</stentry>
           <stentry>block</stentry>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -3235,47 +3235,6 @@
         </strow>
       </simpletable>
     </section>
-    <section id="section_delayresolution" product="base">
-      <title>Delayed Conref Resolution domain elements</title>
-      <simpletable id="simpletable_delayresolution">
-        <sthead>
-          <stentry>Element name</stentry>
-          <stentry>Specialized from</stentry>
-          <stentry>Inherits everything from ancestor?</stentry>
-          <stentry>Block/Inline (presentation)</stentry>
-          <stentry>Block/Inline (translation)</stentry>
-          <stentry>Translatable content?</stentry>
-          <stentry>Translatable attributes?</stentry>
-        </sthead>
-        <strow>
-          <stentry><xmlelement>anchorid</xmlelement></stentry>
-          <stentry><xmlelement>keyword</xmlelement></stentry>
-          <stentry><b>no</b></stentry>
-          <stentry>N/A (metadata)</stentry>
-          <stentry><b>n/a</b></stentry>
-          <stentry><b>no</b></stentry>
-          <stentry/>
-        </strow>
-        <strow>
-          <stentry><xmlelement>anchorkey</xmlelement></stentry>
-          <stentry><xmlelement>keyword</xmlelement></stentry>
-          <stentry><b>no</b></stentry>
-          <stentry>N/A (metadata)</stentry>
-          <stentry><b>n/a</b></stentry>
-          <stentry><b>no</b></stentry>
-          <stentry/>
-        </strow>
-        <strow>
-          <stentry><xmlelement>exportanchors</xmlelement></stentry>
-          <stentry><xmlelement>keywords</xmlelement></stentry>
-          <stentry><b>no</b></stentry>
-          <stentry>N/A (metadata)</stentry>
-          <stentry><b>n/a</b></stentry>
-          <stentry><b>no</b></stentry>
-          <stentry/>
-        </strow>
-      </simpletable>
-    </section>
     <section id="section_hazard" product="base">
       <title>Hazard Statement Domain</title>
       <simpletable id="simpletable_hazard">

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -2861,15 +2861,6 @@
           <stentry>Translatable attributes?</stentry>
         </sthead>
         <strow>
-          <stentry><xmlelement>anchorref</xmlelement></stentry>
-          <stentry><xmlelement>topicref</xmlelement></stentry>
-          <stentry>yes</stentry>
-          <stentry>block</stentry>
-          <stentry>block</stentry>
-          <stentry>yes</stentry>
-          <stentry>no</stentry>
-        </strow>
-        <strow>
           <stentry><xmlelement>keydef</xmlelement></stentry>
           <stentry><xmlelement>topicref</xmlelement></stentry>
           <stentry>yes</stentry>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -42,12 +42,11 @@
           translation setting. So, a translation setting of "yes" or "no" in the table below does
           not guarantee that an element will always, or never, be translated.</li>
         <li>If an element has translatable attributes, they are listed in the last column. Note that
-          the <xmlatt>spectitle</xmlatt> and <xmlatt>specentry</xmlatt> attributes are described
-          with a footnote. <fn id="spectitle">The <xmlatt>spectitle</xmlatt> and
-              <xmlatt>specentry</xmlatt> attributes can contain translatable text. The direct use of
-            fixed-in-the-DTD text by tools is discouraged, in favor of using the value as a lookup
-            string to find the translation outside of the file, using accepted localization methods
-            for generated text. </fn></li>
+          the <xmlatt>spectitle</xmlatt>  attribute is described with a footnote. <fn id="spectitle"
+            >The <xmlatt>spectitle</xmlatt> attribute can contain translatable text. The direct use
+            of fixed-in-the-DTD text by tools is discouraged, in favor of using the value as a
+            lookup string to find the translation outside of the file, using accepted localization
+            methods for generated text. </fn></li>
         <li>The <xmlelement>keyword</xmlelement> element (as well as specializations of
             <xmlelement>keyword</xmlelement>) is an inline, phrase-like element when it appears in
           the body of a document. It <ph >can</ph> also appear in the
@@ -734,7 +733,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>sthead</xmlelement></stentry>
@@ -1766,7 +1765,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>propdeschd</xmlelement></stentry>
@@ -1775,7 +1774,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>properties</xmlelement></stentry>
@@ -1811,7 +1810,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>proptypehd</xmlelement></stentry>
@@ -1820,7 +1819,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>propvalue</xmlelement></stentry>
@@ -1829,7 +1828,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>propvaluehd</xmlelement></stentry>
@@ -1838,7 +1837,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>refbody</xmlelement></stentry>
@@ -1897,7 +1896,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>chdeschd</xmlelement></stentry>
@@ -1906,7 +1905,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>chhead</xmlelement></stentry>
@@ -1951,7 +1950,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>choptionhd</xmlelement></stentry>
@@ -1960,7 +1959,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>chrow</xmlelement></stentry>
@@ -2154,7 +2153,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>condition</xmlelement></stentry>
@@ -2163,7 +2162,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>remedy</xmlelement></stentry>
@@ -2172,7 +2171,7 @@
           <stentry>block</stentry>
           <stentry>block</stentry>
           <stentry>yes</stentry>
-          <stentry><xmlatt>specentry</xmlatt><xref href="elementsMerged.dita#elements/spectitle" type="fn"/></stentry>
+          <stentry/>
         </strow>
         <strow>
           <stentry><xmlelement>responsibleParty</xmlelement></stentry>

--- a/specification/stubs/StubTopic.dita
+++ b/specification/stubs/StubTopic.dita
@@ -72,7 +72,6 @@
       <p><ph id="required-attr">STUB CONTENT</ph></p>
       <p><xref id="mapkeyref" href="#topic_m1s_s5j_c2b/stub-section"></xref></p>
       <p><xref id="outputclass" href="#topic_m1s_s5j_c2b/stub-section"></xref></p>
-      <p><xref id="spectitle" href="#topic_m1s_s5j_c2b/stub-section"></xref></p>
       <codeblock id="concept-codeblock">STUB CONTENT</codeblock>
       <div id="author-attributes">
         <p>STUB CONTENT</p>

--- a/specification/stubs/StubTopic.dita
+++ b/specification/stubs/StubTopic.dita
@@ -51,10 +51,6 @@
           <dt>STUB CONTENT</dt>
           <dd>STUB CONTENT</dd>
         </dlentry>
-        <dlentry id="map-attribute-anchorref">
-          <dt>STUB CONTENT</dt>
-          <dd>STUB CONTENT</dd>
-        </dlentry>
         <dlentry id="map-attribute-id">
           <dt>STUB CONTENT</dt>
           <dd>STUB CONTENT</dd>


### PR DESCRIPTION
Based on today's TC meeting, remove the same markup from tech-comm that was removed from the base vocabulary in https://github.com/oasis-tcs/dita/pull/595