### PR TITLE
Add keyref to sw-d phrases #366

### DIFF
--- a/doctypes/dtd/technicalContent/softwareDomain.mod
+++ b/doctypes/dtd/technicalContent/softwareDomain.mod
@@ -48,7 +48,10 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % msgph.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  msgph %msgph.content;>
 <!ATTLIST  msgph %msgph.attributes;>
@@ -121,7 +124,10 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % filepath.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  filepath %filepath.content;>
 <!ATTLIST  filepath %filepath.attributes;>
@@ -132,7 +138,10 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % userinput.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  userinput %userinput.content;>
 <!ATTLIST  userinput %userinput.attributes;>
@@ -143,7 +152,10 @@
                        "(%words.cnt;)*"
 >
 <!ENTITY % systemoutput.attributes
-              "%univ-atts;"
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
 >
 <!ELEMENT  systemoutput %systemoutput.content;>
 <!ATTLIST  systemoutput %systemoutput.attributes;>

--- a/doctypes/rng/technicalContent/softwareDomain.rng
+++ b/doctypes/rng/technicalContent/softwareDomain.rng
@@ -112,6 +112,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Software Domain//EN"
         </zeroOrMore>
       </define>
       <define name="msgph.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="msgph.element">
@@ -264,6 +267,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Software Domain//EN"
         </zeroOrMore>
       </define>
       <define name="filepath.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="filepath.element">
@@ -294,6 +300,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Software Domain//EN"
         </zeroOrMore>
       </define>
       <define name="userinput.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="userinput.element">
@@ -319,6 +328,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Software Domain//EN"
         </zeroOrMore>
       </define>
       <define name="systemoutput.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
         <ref name="univ-atts"/>
       </define>
       <define name="systemoutput.element">


### PR DESCRIPTION
Per https://github.com/oasis-tcs/dita/issues/366

DITA 1.3 spec says that `@keyref` is available on `filepath`, `msgph`, `userinput`, and `systemoutput`, but it was left off in the grammar files. Agreed to treat this as a fix item.

Follow-up from list: https://lists.oasis-open.org/archives/dita-comment/202007/msg00001.html

At our next meeting we agreed to treat this as a fix: https://lists.oasis-open.org/archives/dita/202008/msg00000.html