### PR TITLE
Relax scale values except simpletable oasis-tcs/dita#397

### DIFF
--- a/doctypes/dtd/technicalContent/reference.mod
+++ b/doctypes/dtd/technicalContent/reference.mod
@@ -142,7 +142,7 @@
                keycol
                           NMTOKEN
                                     #IMPLIED
-               %display-atts;
+               %simpletable-display-atts;
                %univ-atts;"
 >
 <!ELEMENT  properties %properties.content;>

--- a/doctypes/dtd/technicalContent/task.mod
+++ b/doctypes/dtd/technicalContent/task.mod
@@ -332,7 +332,7 @@
                keycol
                           NMTOKEN
                                     '1'
-               %display-atts;
+               %simpletable-display-atts;
                %univ-atts;"
 >
 <!ELEMENT  choicetable %choicetable.content;>

--- a/doctypes/rng/technicalContent/referenceMod.rng
+++ b/doctypes/rng/technicalContent/referenceMod.rng
@@ -266,7 +266,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Reference//EN"
             <data type="NMTOKEN"/>
           </attribute>
         </optional>
-        <ref name="display-atts"/>
+        <ref name="simpletable-display-atts"/>
         <ref name="univ-atts"/>
       </define>
       <define name="properties.element">

--- a/doctypes/rng/technicalContent/taskMod.rng
+++ b/doctypes/rng/technicalContent/taskMod.rng
@@ -678,7 +678,7 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Task//EN"
             <data type="NMTOKEN"/>
           </attribute>
         </optional>
-        <ref name="display-atts"/>
+        <ref name="simpletable-display-atts"/>
         <ref name="univ-atts"/>
       </define>
       <define name="choicetable.element">


### PR DESCRIPTION
Updates base spec to pick up latest changes that remove values from scale att + adds `simpletable-display-atts` group

Update the 2 simpletable specializations in base spec to use that new group