### PR TITLE
Reuse latest attribute list on bookmap

### DIFF
--- a/specification/dita-2.0-technical-content-specification.ditamap
+++ b/specification/dita-2.0-technical-content-specification.ditamap
@@ -39,6 +39,7 @@
     <mapref href="common/key-definitions-tc-library-topics.ditamap"/>
     <mapref href="common/key-definitions-tc-images.ditamap"/>
     <mapref href="baseSpec/specification/common/key-definitions-library-topics.ditamap"/>
+    <mapref href="baseSpec/specification/common/key-definitions-reuse-w-lwdita.ditamap"/>
     <mapref href="langRef/key-definitions-tc-elements.ditamap"/>
     <mapref href="baseSpec/specification/langRef/attributes/key-definitions-ditaref-attributes.ditamap"/>
     <keydef

--- a/specification/langRef/technicalContent/booklists.dita
+++ b/specification/langRef/technicalContent/booklists.dita
@@ -25,8 +25,8 @@
         </section>
         <section id="attributes"><title>Attributes</title>
             <p>The following attributes are available on this element: <ph
-                    conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-                    conkeyref="reuse-attributes/ref-commonmapatts"/>, <xref
+                conkeyref="reuse-attributes/ref-commonmapatts"/>, <ph
+                    conkeyref="reuse-attributes/ref-universalatts"/>, <xref
                     keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
                     keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
                     keyref="attributes-common/attr-scope"><xmlatt>scope</xmlatt></xref>, and <xref

--- a/specification/langRef/technicalContent/bookmap.dita
+++ b/specification/langRef/technicalContent/bookmap.dita
@@ -25,9 +25,7 @@
         ><title>Specialization hierarchy</title>
       <p>The <xmlelement>bookmap</xmlelement> element is specialized from
           <xmlelement>map</xmlelement>. It is defined in the bookmap module.</p></section>
-    <section id="attributes"><title>Attributes</title>
-      <p conkeyref="reuse-attributes/map-attributes-common"/>
-    </section>
+    <section conkeyref="reuse-map/attributes" id="attributes"></section>
     <example id="example" otherprops="examples"
       ><title>Example</title><codeblock>&lt;bookmap xml:lang="en-us">
   &lt;booktitle>


### PR DESCRIPTION
Pulls in lwdita reuse sections, so that we can use the latest attribute definition section for map on the bookmap element. Also fixes the order on booklists.