### PR TITLE
Reuse topic attr section for tech comm topics

### DIFF
--- a/specification/langRef/technicalContent/concept.dita
+++ b/specification/langRef/technicalContent/concept.dita
@@ -28,9 +28,7 @@
       <p>The <xmlelement>concept</xmlelement> element is specialized from
           <xmlelement>topic</xmlelement>. It is defined in the concept module.</p>
     </section>
-    <section id="attributes">
-      <title>Attributes</title><div
-        conkeyref="reuse-attributes/topic-attributes"/></section>
+    <section conkeyref="reuse-topic/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>The following code sample shows a concept topic:</p>

--- a/specification/langRef/technicalContent/glossentry.dita
+++ b/specification/langRef/technicalContent/glossentry.dita
@@ -35,10 +35,7 @@
           <xmlelement>concept</xmlelement> element is specialized from
           <xmlelement>topic</xmlelement>; it is defined in the concept module.</p>
     </section>
-    <section id="attributes">
-      <title>Attributes</title>
-      <div conkeyref="reuse-attributes/topic-attributes"/>
-    </section>
+    <section conkeyref="reuse-topic/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <fig id="fig_f3y_ldk_wbb">

--- a/specification/langRef/technicalContent/glossgroup.dita
+++ b/specification/langRef/technicalContent/glossgroup.dita
@@ -22,10 +22,7 @@
           <xmlelement>concept</xmlelement> element is specialized from
           <xmlelement>topic</xmlelement>; it is defined in the concept module.</p>
     </section>
-    <section id="attributes">
-      <title>Attributes</title>
-      <div conkeyref="reuse-attributes/topic-attributes"/>
-    </section>
+    <section conkeyref="reuse-topic/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;glossgroup id="things" xml:lang="en">

--- a/specification/langRef/technicalContent/reference.dita
+++ b/specification/langRef/technicalContent/reference.dita
@@ -17,10 +17,7 @@
       <p>The <xmlelement>reference</xmlelement> element is specialized from
           <xmlelement>topic</xmlelement>. It is defined in the reference module.</p>
     </section>
-    <section id="attributes">
-      <title>Attributes</title>
-      <div conkeyref="reuse-attributes/topic-attributes"/>
-    </section>
+    <section conkeyref="reuse-topic/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <draft-comment author="Kristen J Eberlein" time="08 November 2022">

--- a/specification/langRef/technicalContent/task.dita
+++ b/specification/langRef/technicalContent/task.dita
@@ -38,10 +38,7 @@
    <p>The <xmlelement>task</xmlelement> element is specialized from <xmlelement>topic</xmlelement>.
         It is defined in the task module.</p>
   </section>
-  <section id="attributes">
-   <title>Attributes</title>
-   <div conkeyref="reuse-attributes/topic-attributes"/>
-  </section>
+  <section conkeyref="reuse-topic/attributes" id="attributes"/>
   <example id="example" otherprops="examples">
    <title>Example</title>
       <p>The following code sample shows that <xmlelement>task</xmlelement>

--- a/specification/langRef/technicalContent/troubleshooting.dita
+++ b/specification/langRef/technicalContent/troubleshooting.dita
@@ -31,10 +31,7 @@
       <p>The <xmlelement>troubleshooting</xmlelement> element is specialized from
           <xmlelement>topic</xmlelement>. It is defined in the troubleshooting module.</p>
     </section>
-    <section id="attributes">
-      <title>Attributes</title>
-      <div conkeyref="reuse-attributes/topic-attributes"/>
-    </section>
+    <section conkeyref="reuse-topic/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>


### PR DESCRIPTION
Switch to the common attribute section used for the base `<topic>`, which has the updated / alphabetized attribute group list)