### PR TITLE
Add format att to glossSymbol

### DIFF
--- a/doctypes/dtd/technicalContent/glossentry.mod
+++ b/doctypes/dtd/technicalContent/glossentry.mod
@@ -358,6 +358,9 @@
               "href
                           CDATA
                                     #IMPLIED
+               format
+                          CDATA
+                                    #IMPLIED
                scope
                           (external |
                            local |

--- a/doctypes/rng/technicalContent/glossentryMod.rng
+++ b/doctypes/rng/technicalContent/glossentryMod.rng
@@ -605,6 +605,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Glossary Entry//EN"
           <attribute name="href"/>
         </optional>
         <optional>
+          <attribute name="format"/>
+        </optional>
+        <optional>
           <attribute name="scope">
             <choice>
               <value>external</value>

--- a/specification/langRef/technicalContent/glossSymbol.dita
+++ b/specification/langRef/technicalContent/glossSymbol.dita
@@ -20,9 +20,10 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-        conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-            keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the
-        attributes defined below.</p>
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes
+        defined below.</p>
       <dl>
         <dlentry conkeyref="reuse-attributes/image-href">
           <dt/>


### PR DESCRIPTION
Adds `@format` to the image specialization `glossSymbol` in the tech-comm set of vocabularies; matches the same change made for base vocabulary to make `href` / `format` / `scope` consistent: https://github.com/oasis-tcs/dita/commit/52440d1d30ec620b7f249ba5376f3836d7715fc4