### PR TITLE
Fix attribute ordering and add draft comment

### DIFF
--- a/specification/langRef/technicalContent/abbreviated-form.dita
+++ b/specification/langRef/technicalContent/abbreviated-form.dita
@@ -93,6 +93,9 @@
     </section>
     <section id="processing-expectations">
       <title>Processing expectations</title>
+      <draft-comment author="rodaande" time="13 December 2022">Similar to above -- this element has
+        a lot of associated processing, enough for an architectural topic; this section likely
+        should include a link to that topic and leave it at that?</draft-comment>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/glossSymbol.dita
+++ b/specification/langRef/technicalContent/glossSymbol.dita
@@ -17,48 +17,7 @@
       <p>The <xmlelement>glossSymbol</xmlelement> element is specialized from
           <xmlelement>image</xmlelement>. It is defined in the glossary entry module.</p>
     </section>
-    <section id="attributes">
-      <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
-          keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
-          keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and the attributes
-        defined below.</p>
-      <dl>
-        <dlentry conkeyref="reuse-attributes/image-href">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-scope">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-height">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-width">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-align">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-scale">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-scalefit">
-          <dt/>
-          <dd/>
-        </dlentry>
-        <dlentry conkeyref="reuse-attributes/image-placement">
-          <dt/>
-          <dd/>
-        </dlentry>
-      </dl>
-    </section>
+    <section conkeyref="reuse-image/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <codeblock>&lt;glossentry id="atlanticpuffin">

--- a/specification/langRef/technicalContent/glossref.dita
+++ b/specification/langRef/technicalContent/glossref.dita
@@ -30,15 +30,15 @@ and expanded versions of that acronym.</shortdesc>
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, <xref keyref="attributes-common/attr-chunk"
-            ><xmlatt>chunk</xmlatt></xref>, <xref keyref="attributes-common/attr-collection-type"
-            ><xmlatt>collection-type</xmlatt></xref>, <xref keyref="attributes-common/attr-keyref"
-            ><xmlatt>keyref</xmlatt></xref>, <xref keyref="attributes-common/attr-linking"
-            ><xmlatt>linking</xmlatt></xref>, <xref keyref="attributes-common/attr-processing-role"
-            ><xmlatt>processing-role</xmlatt></xref>, <xref keyref="attributes-common/attr-search"
-            ><xmlatt>search</xmlatt></xref>, and <xref keyref="attributes-common/attr-toc"
-            ><xmlatt>toc</xmlatt></xref>.</p>
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
+          keyref="attributes-common/attr-chunk"><xmlatt>chunk</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>,
+          <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
+          <xref keyref="attributes-common/attr-search"><xmlatt>search</xmlatt></xref>, and <xref
+          keyref="attributes-common/attr-toc"><xmlatt>toc</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_mwn_xdh_rpb">
           <li>The <xmlatt>href</xmlatt> attribute is a reference to a glossary definigion, typically
             a <xmlelement>glossentry</xmlelement> topic.</li>


### PR DESCRIPTION
Fix attribute order for remaining glossary elements

Reuse `<image>` attributes rather than individually referencing each attribute

Add draft comment to abbreviated-form topic