### PR TITLE
Organize attributes for simpletable specializations

### DIFF
--- a/specification/common/conref-tc-attribute.dita
+++ b/specification/common/conref-tc-attribute.dita
@@ -90,5 +90,28 @@
                                                 <keyword>default</keyword>, or
                                                 <keyword>-dita-use-conref-target</keyword>.</p>
                                                 </div></section>
+                <section id="section_imv_fj3_vvb">
+                        <title>Task and reference table reuse</title>
+                        <p>This group drops <xmlatt>colspan</xmlatt> from the core stentry set, so
+                                cannot reuse that. Also changes "attributes below" to singular
+                                "attribute below".</p>
+                        <div platform="dita" id="stentry-with-rowspan">
+                                <p>The following attributes are available on this element: <ph
+                                                conkeyref="reuse-attributes/ref-table-access-attr"
+                                        />, <ph conkeyref="reuse-attributes/ref-universalatts"/>,
+                                        and the attribute defined below.</p>
+                                <dl>
+                                        <dlentry conkeyref="reuse-attributes/stentry-rowspan">
+                                                <dt/>
+                                                <dd/>
+                                        </dlentry>
+                                </dl>
+                        </div>
+                        <div platform="dita" id="stentry-no-spans">
+                                <p>The following attributes are available on this element: <ph
+                                                conkeyref="reuse-attributes/ref-table-access-attr"
+                                        /> and <ph conkeyref="reuse-attributes/ref-universalatts"/></p>
+                        </div>
+                </section>
                 </conbody>
         </concept>

--- a/specification/langRef/technicalContent/chdesc.dita
+++ b/specification/langRef/technicalContent/chdesc.dita
@@ -22,7 +22,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/choicetable-attr"/>
+      <div conkeyref="reuse-tc-attributes/stentry-no-spans"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/chdeschd.dita
+++ b/specification/langRef/technicalContent/chdeschd.dita
@@ -18,7 +18,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/choicetable-attr"/>
+      <div conkeyref="reuse-tc-attributes/stentry-no-spans"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/choption.dita
+++ b/specification/langRef/technicalContent/choption.dita
@@ -13,7 +13,7 @@
 </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/choicetable-attr"/>
+      <div conkeyref="reuse-tc-attributes/stentry-no-spans"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/choptionhd.dita
+++ b/specification/langRef/technicalContent/choptionhd.dita
@@ -19,7 +19,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-      <div conkeyref="reuse-attributes/choicetable-attr"/>
+         <div conkeyref="reuse-tc-attributes/stentry-no-spans"/>
       </section>
       <example id="example" otherprops="examples">
          <title>Example</title>

--- a/specification/langRef/technicalContent/propdesc.dita
+++ b/specification/langRef/technicalContent/propdesc.dita
@@ -19,13 +19,7 @@
       </section>
       <section id="attributes">
          <title>Attributes</title>
-      <div conkeyref="reuse-attributes/stentry-attr"/>
-         <dl>
-            <dlentry conkeyref="reuse-attributes/stentry-rowspan">
-               <dt/>
-               <dd/>
-            </dlentry>
-         </dl>
+         <div conkeyref="reuse-tc-attributes/stentry-with-rowspan"/>
       </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/propdeschd.dita
+++ b/specification/langRef/technicalContent/propdeschd.dita
@@ -24,7 +24,7 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/choicetable-attr"/>
+      <div conkeyref="reuse-tc-attributes/stentry-no-spans"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/proptype.dita
+++ b/specification/langRef/technicalContent/proptype.dita
@@ -19,13 +19,7 @@
       </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/stentry-attr"/>
-      <dl>
-        <dlentry conkeyref="reuse-attributes/stentry-rowspan">
-          <dt/>
-          <dd/>
-        </dlentry>
-      </dl>
+      <div conkeyref="reuse-tc-attributes/stentry-with-rowspan"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/proptypehd.dita
+++ b/specification/langRef/technicalContent/proptypehd.dita
@@ -20,7 +20,7 @@
             </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/choicetable-attr"/>
+      <div conkeyref="reuse-tc-attributes/stentry-no-spans"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/propvalue.dita
+++ b/specification/langRef/technicalContent/propvalue.dita
@@ -19,13 +19,7 @@
       </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/stentry-attr"/>
-      <dl>
-        <dlentry conkeyref="reuse-attributes/stentry-rowspan">
-          <dt/>
-          <dd/>
-        </dlentry>
-      </dl>
+      <div conkeyref="reuse-tc-attributes/stentry-with-rowspan"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/propvaluehd.dita
+++ b/specification/langRef/technicalContent/propvaluehd.dita
@@ -19,7 +19,7 @@
       </section>
     <section id="attributes">
       <title>Attributes</title>
-      <div conkeyref="reuse-attributes/choicetable-attr"/>
+      <div conkeyref="reuse-tc-attributes/stentry-no-spans"/>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>


### PR DESCRIPTION
Move reuse from the base spec into TC spec for simpletable entry specializations; create one for reuse with rowspan, one for reuse without