### PR TITLE
Fix attribute ordering, correct order and fix typos

### DIFF
--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -28,9 +28,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          keyref="reuse-attributes/ref-displayatts"/>, and <xref keyref="attributes-common/xmlspace"
-            ><xmlatt>xml:space</xmlatt></xref>.</p>
+          conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
+          keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/coderef.dita
+++ b/specification/langRef/technicalContent/coderef.dita
@@ -32,9 +32,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p id="xref-attributes">The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-inclusionatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
           keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>parse</xmlatt> attribute has a default
         value of <keyword>text</keyword>.</p>

--- a/specification/langRef/technicalContent/equation-figure.dita
+++ b/specification/langRef/technicalContent/equation-figure.dita
@@ -58,8 +58,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, and  <ph
-          conkeyref="reuse-attributes/ref-displayatts"/>.</p>
+          conkeyref="reuse-attributes/ref-displayatts"/> and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -56,8 +56,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-inclusionatts"/>, <xref
+          conkeyref="reuse-attributes/ref-inclusionatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, <xref
           keyref="attributes-common/attr-format"><xmlatt>format</xmlatt></xref>, <xref
           keyref="attributes-common/attr-href"><xmlatt>href</xmlatt></xref>, <xref
           keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, and <xref

--- a/specification/langRef/technicalContent/msgblock.dita
+++ b/specification/langRef/technicalContent/msgblock.dita
@@ -37,8 +37,8 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
-          conkeyref="reuse-attributes/ref-displayatts"/>, and  <xref
+          conkeyref="reuse-attributes/ref-displayatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
           keyref="attributes-common/xmlspace"><xmlatt>xml:space</xmlatt></xref>.</p>
     </section>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -53,9 +53,9 @@
     <section id="attributes">
       <title>Attributes</title>
       <p>The following attributes are available on this element: <ph
-          conkeyref="reuse-attributes/ref-universalatts"/>, <ph
           conkeyref="reuse-attributes/ref-inclusionatts"/>, <ph
-          conkeyref="reuse-attributes/ref-linkatts"/>, and <xref
+          conkeyref="reuse-attributes/ref-linkatts"/>, <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>, and <xref
           keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>.</p>
       <p id="attr-exception" outputclass="attr-exception">For this element:<ul id="ul_awv_nmp_rpb">
           <li>The <xmlatt>format</xmlatt> attribute has a default value of

--- a/specification/langRef/technicalContent/synnote.dita
+++ b/specification/langRef/technicalContent/synnote.dita
@@ -33,9 +33,7 @@ itself.</p>
         is defined in the syntax diagram domain module, which is a specialization of the programming
         domain module.</p>
 </section>
-    <section id="attributes">
-      <title>Attributes</title>
-      <div conkeyref="reuse-attributes/fn-attributes"/></section>
+    <section conkeyref="reuse-fn/attributes" id="attributes"/>
     <example id="example" otherprops="examples">
       <title>Example</title>
       <p>In the following code sample, a syntax note reminds the reader where to find information

--- a/specification/langRef/technicalContent/syntaxdiagram.dita
+++ b/specification/langRef/technicalContent/syntaxdiagram.dita
@@ -24,8 +24,9 @@
     </section>
     <section id="attributes">
       <title>Attributes</title>
-      <p>The following attributes are available on this element: <ph conkeyref="reuse-attributes/ref-universalatts"
-      /> and <ph conkeyref="reuse-attributes/ref-displayatts"/>.</p>
+      <p>The following attributes are available on this element: <ph
+          conkeyref="reuse-attributes/ref-displayatts"/> and <ph
+          conkeyref="reuse-attributes/ref-universalatts"/>.</p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>


### PR DESCRIPTION
Fixes group alphabetization, fix `fn` reuse from `synnoteref` that had lost the callout attribute