### PR TITLE
Move formatting conventions content into topics

### DIFF
--- a/specification/langRef/technicalContent/chdeschd.dita
+++ b/specification/langRef/technicalContent/chdeschd.dita
@@ -11,6 +11,11 @@
 </keywords>
 </metadata></prolog>
 <refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>chdeschd</xmlelement> element is
+        typically rendered in a bold font.</p>
+    </section>
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>chdeschd</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/choption.dita
+++ b/specification/langRef/technicalContent/choption.dita
@@ -6,6 +6,14 @@
       >people</ph> can take to complete the
     step.<!--<draft-comment author="robander" time="21 may 2021">Rather than describing this based on presentation (content of an option cell in a table row) can we describe it as an option for completing a step, or similar?</draft-comment>--></shortdesc><prolog><metadata><keywords>
         <indexterm>choice tables<indexterm>options</indexterm></indexterm><indexterm><xmlelement>choption</xmlelement></indexterm><indexterm>task elements<indexterm><xmlelement>choption</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>Unless the <xmlatt>keycol</xmlatt> attribute on the
+          <xmlelement>choicetable</xmlelement> element is set to
+          <keyword>0</keyword>, the contents of the
+          <xmlelement>choiceoption</xmlelement> element is typically
+        rendered in a bold font.</p>
+    </section>
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>
 <p>The <xmlelement>choption</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/choptionhd.dita
+++ b/specification/langRef/technicalContent/choptionhd.dita
@@ -12,6 +12,11 @@
 </keywords>
 </metadata></prolog>
 <refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>chdeschd</xmlelement> element is
+        typically rendered in a bold font.</p>
+    </section>
       <section id="specialization-hierarchy">
          <title>Specialization hierarchy</title>
          <p>The <xmlelement>choptionhd</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -19,6 +19,8 @@
       <title>Rendering expectations</title>
       <p>Processors <term outputclass="RFC-2119">SHOULD</term> preserve line the breaks and spaces
         that are present in the content of a <xmlelement>codeblock</xmlelement> element.</p>
+      <p>The contents of the <xmlelement>codeblock</xmlelement> element is
+        typically rendered in a monospaced font.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/codeph.dita
+++ b/specification/langRef/technicalContent/codeph.dita
@@ -14,6 +14,11 @@
     </metadata>
   </prolog>
   <refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>codeph</xmlelement> element is
+        typically rendered in a monospaced font.</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>codeph</xmlelement> is specialized from <xmlelement>ph</xmlelement>. It is

--- a/specification/langRef/technicalContent/menucascade.dita
+++ b/specification/langRef/technicalContent/menucascade.dita
@@ -18,6 +18,12 @@
     </metadata>
   </prolog>
   <refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>Processors <term outputclass="RFC-2119">SHOULD</term> separate the
+        contents of the <xmlelement>uicontrol</xmlelement> elements with a
+        character to represent the menu cascade.</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>menucascade</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/msgblock.dita
+++ b/specification/langRef/technicalContent/msgblock.dita
@@ -28,6 +28,8 @@
       <p>Processors <term outputclass="RFC-2119">SHOULD</term> preserve the
         line breaks and spaces that are present in the content of a
           <xmlelement>msgblock</xmlelement> element.</p>
+      <p>The contents of the <xmlelement>msgblock</xmlelement> element is
+        typically rendered in a monospaced font.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/numcharref.dita
+++ b/specification/langRef/technicalContent/numcharref.dita
@@ -21,6 +21,12 @@
         without any leading or trailing characters, for example, <keyword>10</keyword> or
           <keyword>x0a</keyword>.</p>
     </section>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>numcharref</xmlelement> element is
+        typically rendered with a leading ampersand (&amp;) and a trailing
+        semi-colon (;).</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>numcharref</xmlelement> element is specialized

--- a/specification/langRef/technicalContent/parameterentity.dita
+++ b/specification/langRef/technicalContent/parameterentity.dita
@@ -25,6 +25,12 @@
         name without a leading percentage sign or trailing semi-colon, for example,
           <keyword>keyword.content</keyword>.</p>
     </section>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>parameterentity</xmlelement>
+        element is typically rendered with a leading percentage sign (%)
+        and a trailing semi-colon (;).</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>parameterentity</xmlelement> element is

--- a/specification/langRef/technicalContent/screen.dita
+++ b/specification/langRef/technicalContent/screen.dita
@@ -20,6 +20,9 @@
       <p>Processors <term outputclass="RFC-2119">SHOULD</term> preserve the
         line breaks and spaces that are present in the content of a
           <xmlelement>screen</xmlelement> element.</p>
+      <p>The contents of the <xmlelement>screen</xmlelement> element is
+        typically enclosed within a box to suggest a computer display
+        screen. It also is typically rendered in a monospaced font.</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/shortcut.dita
+++ b/specification/langRef/technicalContent/shortcut.dita
@@ -15,6 +15,11 @@
     </metadata>
   </prolog>
   <refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>shortcut</xmlelement> element is
+        typically underlined.</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>shortcut</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/syntaxdiagram.dita
+++ b/specification/langRef/technicalContent/syntaxdiagram.dita
@@ -16,6 +16,12 @@
     </metadata>
   </prolog>
   <refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>Traditionally, the syntax diagram is formatted with "railroad
+        tracks" that connect the units of the syntax together, but the
+        presentation might vary depending on the output media.</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>syntaxdiagram</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/textentity.dita
+++ b/specification/langRef/technicalContent/textentity.dita
@@ -24,6 +24,12 @@
         without the ampersand and semi-colon delimiters, for example,
         <keyword>hi-d-att</keyword>.</p>
     </section>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>numcharref</xmlelement> element is
+        typically rendered with a leading ampersand (&amp;) and a trailing
+        semi-colon (;).</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>textentity</xmlelement> element is specialized

--- a/specification/langRef/technicalContent/varname.dita
+++ b/specification/langRef/technicalContent/varname.dita
@@ -15,6 +15,11 @@
     </metadata>
   </prolog>
   <refbody>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>varname</xmlelement> element is
+        typically rendered in an italic font.</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>varname</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/xmlatt.dita
+++ b/specification/langRef/technicalContent/xmlatt.dita
@@ -20,9 +20,14 @@
   <refbody>
     <section id="usage-information">
       <title>Usage information</title>
-      <p>The content of the <xmlelement>xmlatt</xmlelement> element should be the attribute name
-        without commercial at symbol (@) or equals character (=) , for example,
-          <keyword>audience</keyword>.</p>
+      <p>The content of the <xmlelement>xmlatt</xmlelement> element should
+        be the attribute name without commercial at symbol (@) or equals
+        character (=), for example, <keyword>audience</keyword>.</p>
+    </section>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>xmlatt</xmlelement> element is
+        typically rendered with a preceding commercial at symbol (@).</p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/xmlelement.dita
+++ b/specification/langRef/technicalContent/xmlelement.dita
@@ -23,6 +23,12 @@
       <p>The content of the <xmlelement>xmlelement</xmlelement> element should be the element type
         name without leading or trailing angle brackets.</p>
     </section>
+    <section id="rendering-expectations">
+      <title>Rendering expectations</title>
+      <p>The contents of the <xmlelement>xmlelement</xmlelement> element is
+        typically rendered with leading (&lt;) and trailing (>) angle
+        brackets.</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>xmlelement</xmlelement> element is specialized

--- a/specification/non-normative/formatting-expectations.dita
+++ b/specification/non-normative/formatting-expectations.dita
@@ -9,54 +9,6 @@
     <refbody>
         <section>
             <p><!--<draft-comment author="robander" time="25 May 2021">I can't remember … is this expected to include the content of every "Rendering expectations" section in this spec, or did we have a distinction between rendering and formatting? Right now it seems pretty inconsistent, for example we say chdeschd is bold here but that topic doesn't have a "rendering" section, while codeblock here says to use monospace but doesn't say anything about the required white-space and newlines.<p>If there is a distinction, I've already forgotten it, so we should probably explain here what the difference is.</p><div><p>Kris Eberlein, 06 October 2022</p><p>Yes, we make a clear distinction between "rendering" and "formatting". Formatting is NEVER normative. It's always implementation specific. Your implementation might decide to format bold elements using purple text.</p><p>"Rendering" is normative. For example, we state that <xmlelement>stepsection</xmlelement> elements (if rendered), must not be numbered.</p></div></draft-comment>--></p>
-        </section><simpletable frame="all" relcolwidth="1* 4*">
-            
-            
-                
-                
-                
-                    <sthead>
-                        <stentry>Element</stentry>
-                        <stentry>Suggested formatting</stentry>
-                    </sthead>
-                    <strow>
-                        <stentry><xmlelement>numcharref</xmlelement></stentry>
-                        <stentry>Surround the contents of the <xmlelement>numcharref</xmlelement>
-                            element with a leading ampersand (&amp;) and a trailing semi-colon
-                            (;).</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>parameterentity</xmlelement></stentry>
-                        <stentry>Surround the contents of the <xmlelement>numcharref</xmlelement>
-                            element with a leading percentage sign (%) and a trailing semi-colon
-                            (;).</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>syntaxdiagram</xmlelement></stentry>
-                        <stentry>Traditionally, the syntax diagram is formatted with "railroad tracks"
-                            that connect the units of the syntax together, but the presentation
-                            might differ depending on the output media.</stentry>
-                    </strow>
-
-                    <strow>
-                        <stentry><xmlelement>textentity</xmlelement></stentry>
-                        <stentry>Surround the contents of the <xmlelement>textentity</xmlelement>
-                            element with a leading ampersand (&amp;) and a trailing semi-colon
-                            (;).</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>xmlatt</xmlelement></stentry>
-                        <stentry>Precede the contents of the
-            <xmlelement>xmlatt</xmlelement> element with a commercial at
-          symbol (@).</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>xmlelement</xmlelement></stentry>
-                        <stentry>Surround the contents of the <xmlelement>xmlelement</xmlelement>
-                            element with leading (&lt;) and trailing (>) angle brackets.</stentry>
-                    </strow>
-                
-            
-        </simpletable>
+        </section>
     </refbody>
 </reference>

--- a/specification/non-normative/formatting-expectations.dita
+++ b/specification/non-normative/formatting-expectations.dita
@@ -40,16 +40,6 @@
                                 <xmlelement>choptionhd</xmlelement> element.</stentry>
                     </strow>
                     <strow>
-                        <stentry><xmlelement>codeblock</xmlelement></stentry>
-                        <stentry>Use a monospaced font for the contents of the
-                                <xmlelement>codeblock</xmlelement> element.</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>codeph</xmlelement></stentry>
-                        <stentry>Use a monospaced font for the contents of the
-                                <xmlelement>codeph</xmlelement> element.</stentry>
-                    </strow>
-                    <strow>
                         <stentry><xmlelement>menucascade</xmlelement></stentry>
                         <stentry>Separate <xmlelement>uicontrol</xmlelement> elements with a character
                             to represent the menu cascade.</stentry>
@@ -65,15 +55,6 @@
                         <stentry>Surround the contents of the <xmlelement>numcharref</xmlelement>
                             element with a leading percentage sign (%) and a trailing semi-colon
                             (;).</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>screen</xmlelement></stentry>
-                        <stentry>Enclose the contents of the <xmlelement>screen</xmlelement> element
-                            with a box to suggest a computer display screen.</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>shortcut</xmlelement></stentry>
-                        <stentry>Highlight the keyboard shortcut with underlining.</stentry>
                     </strow>
                     <strow>
                         <stentry><xmlelement>syntaxdiagram</xmlelement></stentry>
@@ -103,10 +84,6 @@
                         <stentry><xmlelement>xmlelement</xmlelement></stentry>
                         <stentry>Surround the contents of the <xmlelement>xmlelement</xmlelement>
                             element with leading (&lt;) and trailing (>) angle brackets.</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement/></stentry>
-                        <stentry/>
                     </strow>
                 
             

--- a/specification/non-normative/formatting-expectations.dita
+++ b/specification/non-normative/formatting-expectations.dita
@@ -19,31 +19,6 @@
                         <stentry>Element</stentry>
                         <stentry>Suggested formatting</stentry>
                     </sthead>
-                
-                
-                    <strow>
-                        <stentry><xmlelement>chdeschd</xmlelement></stentry>
-                        <stentry>Apply bold highlighting to the contents of the
-                                <xmlelement>chdeschd</xmlelement> element.</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>choicetable</xmlelement></stentry>
-                        <stentry>
-                            <p>Unless the <xmlatt>keycol</xmlatt> attribute is set to
-                                    <keyword>0</keyword>, processors typically apply bold
-                                highlighting to the contents of the "Option" column.</p>
-                        </stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>choptionhd</xmlelement></stentry>
-                        <stentry>Apply bold highlighting to the contents of the
-                                <xmlelement>choptionhd</xmlelement> element.</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>menucascade</xmlelement></stentry>
-                        <stentry>Separate <xmlelement>uicontrol</xmlelement> elements with a character
-                            to represent the menu cascade.</stentry>
-                    </strow>
                     <strow>
                         <stentry><xmlelement>numcharref</xmlelement></stentry>
                         <stentry>Surround the contents of the <xmlelement>numcharref</xmlelement>
@@ -68,11 +43,6 @@
                         <stentry>Surround the contents of the <xmlelement>textentity</xmlelement>
                             element with a leading ampersand (&amp;) and a trailing semi-colon
                             (;).</stentry>
-                    </strow>
-                    <strow>
-                        <stentry><xmlelement>var</xmlelement></stentry>
-                        <stentry>Apply italic highlighting to the contents of the
-                                <xmlelement>var</xmlelement> element.</stentry>
                     </strow>
                     <strow>
                         <stentry><xmlelement>xmlatt</xmlelement></stentry>


### PR DESCRIPTION
Move formatting conventions content into "Rendering expectations" sections of element-reference topics