### PR TITLE
Drop reference to xNAL from bookmap container

### DIFF
--- a/specification/langRef/containers/bookmap-content-elements.dita
+++ b/specification/langRef/containers/bookmap-content-elements.dita
@@ -5,10 +5,6 @@
 <title>Bookmap content elements</title>
 <shortdesc>The Bookmap specialization of <xmlelement>map</xmlelement> supports standard
 book production for collections of DITA topics.</shortdesc>
-<conbody>
-<p>The OASIS document type for the bookmap specialization also includes
-substantial book metadata for describing authors, based on the eXtensible
-Name and Address Language, or xNAL.</p>
-</conbody>
+<conbody/>
 </concept>
 


### PR DESCRIPTION
xNAL content has been removed for https://github.com/oasis-tcs/dita/issues/898

This follows up an earlier commit that removed the element reference and doctypes, with a change that removes mention of the domain from a container topic