### PR TITLE
Escape ampersand in codeblock sample

### DIFF
--- a/specification/langRef/technicalContent/codeblock.dita
+++ b/specification/langRef/technicalContent/codeblock.dita
@@ -39,9 +39,9 @@
       <p>The following code sample shows how the <xmlelement>codeblock</xmlelement> element can be
         used to <ph rev="review-c">tag an excerpt from an XSLT stylesheet:</ph></p>
       <codeblock rev="review-c" base="ci-xml"><b>&lt;codeblock></b>
-  &lt;xsl:template match="*[contains(@outputclass,'green')]">
-    &lt;xsl:attribute name="color">#006400;&lt;/xsl:attribute>
-  &lt;/xsl:template>
+  &amp;lt;xsl:template match="*[contains(@outputclass,'green')]">
+    &amp;lt;xsl:attribute name="color">#006400;&amp;lt;/xsl:attribute>
+  &amp;lt;/xsl:template>
 <b>&lt;/codeblock></b></codeblock>
       <p rev="review-c">For a sample of how this element can be combined with
           <xmlelement>coderef</xmlelement> to embed external code samples, see <xref


### PR DESCRIPTION
Need to escape the ampersand in `&lt;xsl:template` so that the entire sample can be pasted into a valid DITA document as a codeblock