### PR TITLE
Remove xnal from bookmap shells oasis-tcs/dita#898

### DIFF
--- a/doctypes/dtd/bookmap/bookmap.dtd
+++ b/doctypes/dtd/bookmap/bookmap.dtd
@@ -125,11 +125,6 @@
          "../base/utilitiesDomain.ent"
 >%ut-d-dec;
 
-<!ENTITY % xnal-d-dec
-  PUBLIC "-//OASIS//ENTITIES DITA 2.0 XNAL Domain//EN"
-         "../xnal/xnalDomain.ent"
->%xnal-d-dec;
-
 <!ENTITY % xml-d-dec
   PUBLIC "-//OASIS//ENTITIES DITA 2.0 XML Domain//EN"
          "../technicalContent/xmlDomain.ent"
@@ -219,9 +214,6 @@
                         ">
 <!ENTITY % metadata     "metadata |
                          %relmgmt-d-metadata;
-                        ">
-<!ENTITY % author       "author |
-                         %xnal-d-author;
                         ">
 
 <!-- ============================================================= -->
@@ -349,11 +341,6 @@
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 Utilities Domain//EN"
          "../base/utilitiesDomain.mod"
 >%ut-d-def;
-
-<!ENTITY % xnal-d-def
-  PUBLIC "-//OASIS//ELEMENTS DITA 2.0 XNAL Domain//EN"
-         "../xnal/xnalDomain.mod"
->%xnal-d-def;
 
 <!ENTITY % xml-d-def
   PUBLIC "-//OASIS//ELEMENTS DITA 2.0 XML Domain//EN"

--- a/doctypes/rng/bookmap/bookmap.rng
+++ b/doctypes/rng/bookmap/bookmap.rng
@@ -102,7 +102,6 @@ PUBLIC "-//OASIS//DTD DITA 2.0 BookMap//EN"
      <include href="../technicalContent/syntaxdiagramDomain.rng" dita:since="2.0"/>
      <include href="../technicalContent/uiDomain.rng"/>
      <include href="urn:pubid:oasis:names:tc:dita:rng:utilitiesDomain.rng:2.0"/>
-     <include href="../xnal/xnalDomain.rng"/>
      <include href="../technicalContent/xmlDomain.rng" dita:since="1.3"/>
   </div>
   <div>


### PR DESCRIPTION
Xnal modules were removed, but the configured bookmap shells still had references to them - removing per oasis-tcs/dita#898