### PR TITLE
Updates to glossary topics, with one reverted file

### DIFF
--- a/specification/archSpec/technicalContent/dita-glossarygroup-topic.dita
+++ b/specification/archSpec/technicalContent/dita-glossarygroup-topic.dita
@@ -4,27 +4,68 @@
 <concept xml:lang="en-us" id="glossary-group-topic">
   <title>Glossary group</title>
   <abstract>
-    <shortdesc>Glossary group topics are designed to enable authors to
-      author and edit glossary entries in a single file, rather than
-      working with many single glossary entry topics.</shortdesc>
+    <shortdesc>Glossary group topics enable the authoring of glossary entries in a single topic
+      document, rather than working with many individual glossary entry topic documents.</shortdesc>
     <!--<shortdesc>The glossary group (<xmlelement>glossgroup</xmlelement>) topic enables authors to include one or more glossary entry (<xmlelement>glossentry</xmlelement>) topics in a single collection file, rather than authoring each glossary entry topic in a separate file. The glossary group topic is a specialization of concept.<draft-comment author="robander" audience="spec-editors" time="25 May 2021">Do we need an example here like in the other topics? Perhaps an example of a term with 2 senses, managed in one file?</draft-comment></shortdesc>-->
   </abstract>
   <conbody>
     <section id="purpose">
       <title>Purpose</title>
-      <p>The glossary group topic has the following purposes:</p>
-      <ul>
-        <li/>
-      </ul>
+      <p>The glossary group topic type is primarily an authoring convenience where it is useful to
+        author and manage multiple glossary entries in a single file.</p>
+      <p>Note that it is possible to create separate topicrefs, such as
+        <xmlelement>glossref</xmlelement>, for individual glossary entry topics within a glossary
+        group topic, for example:<codeblock id="codeblock_dyt_3bx_czb">&lt;map>
+  ...
+  &lt;topicref keys="glossary" href="glossary/glossary-group.dita">
+    <b>&lt;glossref keys="term-01" href="glossary/glossary-group.dita#term-01"/></b>
+    &lt;glossref keys="term-02" href="glossary/glossary-group.dita#term-02"/>
+    ...
+    &lt;glossref keys="term-99" href="glossary/glossary-group.dita#term-99"/>
+  &lt;/topicref>
+&lt;/map></codeblock></p>
     </section>
     <section id="content-model">
       <title>Content model</title>
-      <p/>
+      <p>A glossary group topic has a required title, an optional prolog, and zero or more
+        <xmlelement>glossentry</xmlelement> or <xmlelement>glossgroup</xmlelement> elements.</p>
     </section>
     <example>
       <title>Example</title>
-      <p>The following code sample shows a glossary group topic:</p>
-      <codeblock/>
+      <p>The following code sample shows a glossary group topic with multiple nested glossary
+        groups, one for each English letter group.</p>
+      <codeblock><b>&lt;glossgroup id="glossgroup" xml:lang="en-US"></b>
+  &lt;title>Glossary&lt;/title>
+  <b>&lt;glossgroup id="glossgroup-a"></b>
+    &lt;title>A&lt;/title>
+    &lt;glossentry id="apple-fruit">
+      &lt;glossterm>apple&lt;/glossterm>
+      &lt;glossdef>A round, edible fruit produced by an apple tree (Malus domestica).&lt;/glossdef>
+    &lt;/glossentry>
+    &lt;glossentry id="apple-corp">
+      &lt;glossterm>Apple Inc.&lt;/glossterm>
+      &lt;glossdef>An American multinational technology company headquartered in Cupertino, California.&lt;/glossdef>
+      &lt;glossBody>
+        &lt;glossAlt>
+          &lt;glossAbbreviation>APPL&lt;/glossAbbreviation>
+        &lt;/glossAlt>
+      &lt;/glossBody>
+    &lt;/glossentry>
+  <b>&lt;/glossgroup></b>
+  ... (groups B to Y here ) ...
+  <b>&lt;glossgroup id="glossgroup-z"></b>
+    &lt;title>Z&lt;/title>
+    &lt;glossentry id="ziziphus-fruit">
+      &lt;glossterm>ziziphus&lt;/glossterm>
+      &lt;glossdef>The edible drupe of ziziphus shrubs (Ziziphus jujuba).&lt;/glossdef>
+      &lt;glossBody>
+        &lt;glossAlt>
+          &lt;glossSynonym>jujube&lt;/glossSynonym>
+        &lt;/glossAlt>
+      &lt;/glossBody>
+    &lt;/glossentry>
+  <b>&lt;/glossgroup></b>
+<b>&lt;/glossgroup></b></codeblock>
     </example>
   </conbody>
 </concept>

--- a/specification/langRef/technicalContent/glossgroup.dita
+++ b/specification/langRef/technicalContent/glossgroup.dita
@@ -3,8 +3,8 @@
  "reference.dtd">
 <reference id="glossgroup" xml:lang="en-us">
   <title><xmlelement>glossgroup</xmlelement></title>
-  <shortdesc>The <xmlelement>glossgroup</xmlelement> is a specialized topic that can contain
-    multiple <xmlelement>glossentry</xmlelement> topics within a single document.</shortdesc>
+  <shortdesc>A glossary group topic organizes related glossary entry topics within a single topic
+    document.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -15,6 +15,11 @@
     </metadata>
   </prolog>
   <refbody>
+    <section id="usage-information">
+      <title>Usage information</title>
+      <p>Glossary groups are primarily a convenience for authoring when it is useful to author
+        multiple glossary entry topics in a single document.</p>
+    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>glossgroup</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/glossref.dita
+++ b/specification/langRef/technicalContent/glossref.dita
@@ -3,24 +3,25 @@
  "reference.dtd">
 <reference id="glossref" xml:lang="en-us">
 <title><xmlelement>glossref</xmlelement></title>
-<shortdesc>The <xmlelement>glossref</xmlelement> element is a convenience element in maps for
-creating a reference to a glossary topic. It has a required <xmlatt>keys</xmlatt> attribute, which
-forces the author to create a key by which inline terms can reference their definition. For example,
-when <xmlelement>glossentry</xmlelement> topics are used to define acronyms, this reminds authors to
-create a key which <xmlelement>abbreviated-form</xmlelement> elements can use to reference the short
-and expanded versions of that acronym.</shortdesc>
+<shortdesc>Glossary reference topic references are a convenience element for creating references to
+    glossary topics. It has a required <xmlatt>keys</xmlatt> attribute, which forces the author to
+    create a key by which inline terms can reflect the glossary terms and become navigable links to
+    the glossary definition. For example, when <xmlelement>glossentry</xmlelement> topics are used
+    to define acronyms, this reminds authors to create a key that
+    <xmlelement>abbreviated-form</xmlelement> elements can use to refer to the short and expanded
+    versions of the acronyms.</shortdesc>
 <prolog><metadata>
 <keywords><indexterm><xmlelement>glossref</xmlelement></indexterm>
         <indexterm>glossary-related
           elements<indexterm><xmlelement>glossref</xmlelement></indexterm></indexterm></keywords>
 </metadata></prolog>
 <refbody>
-    <section id="usage-information"><title>Usage information</title>Note that the key value does not
-      need to match the target term or acronym. In fact, using a more qualified value for the
-        <xmlatt>keyref</xmlatt> will reduce conflicts in situations where the same term or acronym
-        <ph>might</ph> resolve in many ways. For example, an information set could use
-        <q>cars.abs</q> as the key for the term Anti-lock Braking System, and <q>ship.abs</q> to
-      refer to the term American Bureau of Shipping.</section>
+    <section id="usage-information"><title>Usage information</title>Note that the key names defined
+      in the <xmlatt>keys</xmlatt> attribute do not need to match the target term or acronym. Using
+      more qualified values or distinct key scopes for the keys will reduce conflicts in situations
+      where the same key name might be associated with different terms. For example, an information
+      set could use <q>cars.abs</q> as the key for the term Anti-lock Braking System, and
+      <q>ship.abs</q> to refer to the term American Bureau of Shipping.</section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>glossref</xmlelement> element is specialized from
@@ -46,17 +47,30 @@ and expanded versions of that acronym.</shortdesc>
           <li>The <xmlatt>linking</xmlatt> attribute has a default value of
             <keyword>none</keyword>.</li>
           <li>The <xmlatt>toc</xmlatt> attribute has a default value of <keyword>no</keyword>.</li>
+        <li>The <xmlatt>search</xmlatt> attribute has a default value of <keyword>no</keyword>.</li>
         </ul></p>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>
+      <p>The following code sample demonstrates using a <xmlelement>glossref</xmlelement> element to
+        include a car-specific glossary entry in the map. The glossary reference has the key "abs".
+        The <xmlelement>glossref</xmlelement> element is within the key scope "cars", so references
+        to this glossary entry from outside the "cars" key scope will be of the form
+        <codeph>&lt;keyword keyref="cars.abs"/></codeph>.</p>
       <codeblock>&lt;map>
   &lt;!-- ... -->
   &lt;topicref href="car-maintenance.dita"/>
   &lt;!-- ... -->
-  &lt;glossref keys="cars.abs" href="antiLockBrake.dita"/>
-  &lt;!-- ... key declarations for other referenced acronyms ... -->
+  &lt;topichead keyscope="cars">
+   &lt;topicmeta>&lt;navtitle>Car Terminalogy&lt;/navtitle>&lt;/topicmeta>
+   <b>&lt;glossref keys="abs" href="glossary/a/antiLockBrake.dita"/></b>
+   &lt;!-- ... key declarations for other referenced acronyms ... -->
+  &lt;/topichead>
 &lt;/map></codeblock>
+      <p>When this is map is rendered using typical output processing, the table of contents will
+        have an entry for the topic head "Car Terminology" but will not have entries for the
+        glossary entries because <xmlelement>glossref</xmlelement> sets the value of
+        <xmlatt>toc</xmlatt> to <keyword>no</keyword> by default.</p>
     </example>
 </refbody>
 </reference>


### PR DESCRIPTION
Integrates changes from https://github.com/oasis-tcs/dita-techcomm/pull/246

but backs out changes to `glossentry.dita` which Dawn is actively working on