### PR TITLE
Add topicmeta to empty book elements oasis-tcs/dita#911

### DIFF
--- a/doctypes/dtd/bookmap/bookmap.mod
+++ b/doctypes/dtd/bookmap/bookmap.mod
@@ -877,7 +877,7 @@
 
 <!--                    LONG NAME: Book Abstract                   -->
 <!ENTITY % bookabstract.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % bookabstract.attributes
               "%chapter-atts;"
@@ -888,7 +888,7 @@
 
 <!--                    LONG NAME: Dedication                      -->
 <!ENTITY % dedication.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % dedication.attributes
               "%chapter-atts;"
@@ -972,7 +972,7 @@
 
 <!--                    LONG NAME: Amendments                      -->
 <!ENTITY % amendments.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % amendments.attributes
               "%chapter-atts;"
@@ -983,7 +983,7 @@
 
 <!--                    LONG NAME: Colophon                        -->
 <!ENTITY % colophon.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % colophon.attributes
               "%chapter-atts;"
@@ -1023,7 +1023,7 @@
 
 <!--                    LONG NAME: Table of Contents               -->
 <!ENTITY % toc.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % toc.attributes
               "%chapter-atts;"
@@ -1034,7 +1034,7 @@
 
 <!--                    LONG NAME: Figure List                     -->
 <!ENTITY % figurelist.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % figurelist.attributes
               "%chapter-atts;"
@@ -1045,7 +1045,7 @@
 
 <!--                    LONG NAME: Table List                      -->
 <!ENTITY % tablelist.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % tablelist.attributes
               "%chapter-atts;"
@@ -1056,7 +1056,7 @@
 
 <!--                    LONG NAME: Abbreviation List               -->
 <!ENTITY % abbrevlist.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % abbrevlist.attributes
               "%chapter-atts;"
@@ -1067,7 +1067,7 @@
 
 <!--                    LONG NAME: Trademark List                  -->
 <!ENTITY % trademarklist.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % trademarklist.attributes
               "%chapter-atts;"
@@ -1078,7 +1078,7 @@
 
 <!--                    LONG NAME: Bibliography List               -->
 <!ENTITY % bibliolist.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % bibliolist.attributes
               "%chapter-atts;"
@@ -1101,7 +1101,7 @@
 
 <!--                    LONG NAME: Index List                      -->
 <!ENTITY % indexlist.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % indexlist.attributes
               "%chapter-atts;"
@@ -1112,7 +1112,7 @@
 
 <!--                    LONG NAME: Book List                       -->
 <!ENTITY % booklist.content
-                       "EMPTY"
+                       "(%topicmeta;)?"
 >
 <!ENTITY % booklist.attributes
               "%chapter-atts;"

--- a/doctypes/rng/bookmap/bookmapMod.rng
+++ b/doctypes/rng/bookmap/bookmapMod.rng
@@ -1722,7 +1722,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Book Abstract</a:documentation>
       <define name="bookabstract.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="bookabstract.attributes">
         <ref name="chapter-atts"/>
@@ -1743,7 +1745,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Dedication</a:documentation>
       <define name="dedication.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="dedication.attributes">
         <ref name="chapter-atts"/>
@@ -1919,7 +1923,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Amendments</a:documentation>
       <define name="amendments.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="amendments.attributes">
         <ref name="chapter-atts"/>
@@ -1940,7 +1946,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Colophon</a:documentation>
       <define name="colophon.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="colophon.attributes">
         <ref name="chapter-atts"/>
@@ -2006,7 +2014,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Table of Contents</a:documentation>
       <define name="toc.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="toc.attributes">
         <ref name="chapter-atts"/>
@@ -2027,7 +2037,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Figure List</a:documentation>
       <define name="figurelist.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="figurelist.attributes">
         <ref name="chapter-atts"/>
@@ -2048,7 +2060,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Table List</a:documentation>
       <define name="tablelist.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="tablelist.attributes">
         <ref name="chapter-atts"/>
@@ -2069,7 +2083,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Abbreviation List</a:documentation>
       <define name="abbrevlist.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="abbrevlist.attributes">
         <ref name="chapter-atts"/>
@@ -2090,7 +2106,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Trademark List</a:documentation>
       <define name="trademarklist.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="trademarklist.attributes">
         <ref name="chapter-atts"/>
@@ -2111,7 +2129,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Bibliography List</a:documentation>
       <define name="bibliolist.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="bibliolist.attributes">
         <ref name="chapter-atts"/>
@@ -2158,7 +2178,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Index List</a:documentation>
       <define name="indexlist.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="indexlist.attributes">
         <ref name="chapter-atts"/>
@@ -2179,7 +2201,9 @@ PUBLIC "-//OASIS//ELEMENTS DITA 2.0 BookMap//EN"
     <div>
       <a:documentation>LONG NAME: Book List</a:documentation>
       <define name="booklist.content">
-        <empty/>
+        <optional>
+          <ref name="topicmeta"/>
+        </optional>
       </define>
       <define name="booklist.attributes">
         <ref name="chapter-atts"/>


### PR DESCRIPTION
Adds topicmeta as child of topicref specliazations that were previously EMPTY, so that they retain the ability to set navigation titles (and/or specify other metadata), as noted in https://github.com/oasis-tcs/dita/issues/911