### PR TITLE
Updates for working draft #18

### DIFF
--- a/specification/archSpec/technicalContent/dita-concept-topic.dita
+++ b/specification/archSpec/technicalContent/dita-concept-topic.dita
@@ -19,7 +19,6 @@
           that they need to perform</li>
       </ul>
     </section>
-    <!--<section><title>The purpose of the concept information type</title><p>Concepts provide background that helps readers understand essential information about a product, a task, a process, or any other conceptual or descriptive information. A concept might be an extended definition of a major abstraction such as a process or function. Conceptual information might explain the nature and components of a product and describe how it fits into a category of products. Conceptual information helps readers to map their knowledge and understanding to the tasks they need to perform and to provide other essential information about a product, process, or system.</p></section>-->
     <section id="content-model">
       <title>Content model</title>
       <p>The body of a concept topic can contain the following document
@@ -29,8 +28,8 @@
           paragraphs, lists, tables, figures, etc.</li>
         <li>Concept body divisions: <xref keyref="elements-conbodydiv"
               ><xmlelement>conbodydiv</xmlelement></xref></li>
-        <li>Examples</li>
-        <li>Sections</li>
+        <li>Examples: <xmlelement>example</xmlelement></li>
+        <li>Sections: <xmlelement>section</xmlelement></li>
       </ul>
       <p>However, after a <ph rev="review-b">section, example, or concept
           body division</ph> is introduced into the topic structure, it can
@@ -47,9 +46,6 @@
         </ul>
       </div>
     </section>
-    <!--<section><title>The structure of the concept topic</title><p>The concept topic is specialized from the base topic information type. The top-level element for a DITA concept topic is the <xmlelement>concept</xmlelement> element. Every concept topic contains the standard topic elements, including title, short descriptions or abstract, prolog, a body, and related links.</p><p>The <xmlelement>conbody</xmlelement> element holds the main body-level elements of the concept topic. Like the <xmlelement>body</xmlelement> element of a base topic, the <xmlelement>conbody</xmlelement> allows paragraphs, lists, tables, figures and other general elements. It also provides two key elements that allow authors to subdivide the topic into parts, with or without titles. These subdivisions are called sections and examples. The <xmlelement>conbody</xmlelement> also allows <xmlelement>div</xmlelement> and <xmlelement>conbodydiv</xmlelement> to facilitate grouping elements in the <xmlelement>conbody</xmlelement>.</p></section>-->
-    <!--<section><title>Limitations within <xmlelement>conbody</xmlelement></title><p>The <xmlelement>conbody</xmlelement> provides for an unlimited number of subdivisions in the form of sections and examples. However, once an author decides to incorporate a section or example in the <xmlelement>conbody</xmlelement>, only additional sections or examples are allowed. Sections and examples can not nest, meaning that only one level of subdivision is permitted in the concept topic.</p></section>-->
-    <!--<section><title>Concept body primary subdivisions</title><draft-comment author="robander" audience="spec-editors" time="25 may 2021">Wondering if we really want to redefine sections and examples here? these are specific to concepts but that means they are definitions of the element that are not in sync with the definition in the base spec. I think the "same content model as section" is right now, but was not in 1.3 when section allowed sectiondiv.</draft-comment><dl><dlentry><dt><xmlelement>section</xmlelement> </dt><dd>Represents an organizational division in a concept topic. Sections organize subsets of information within a larger topic. You can only include a simple list of peer sections in a topic; sections cannot be nested. A section can have an optional title. </dd></dlentry><dlentry><dt><xmlelement>example</xmlelement> </dt><dd>Provides examples that illustrate or support the current topic. The <xmlelement>example</xmlelement> element has the same content model as <xmlelement>section</xmlelement>. </dd></dlentry></dl></section>-->
     <example otherprops="examples" id="example" rev="review-b">
       <title>Example</title>
       <p>The following code sample contains a simple concept topic:</p>

--- a/specification/archSpec/technicalContent/dita-generic-task-topic.dita
+++ b/specification/archSpec/technicalContent/dita-generic-task-topic.dita
@@ -22,7 +22,7 @@
                     ><xmlelement>prerequisites</xmlelement></xref></li>
               <li>Contextual information: <xref keyref="elements-context"
                     ><xmlelement>context</xmlelement></xref></li>
-              <li>Sections: <xmlelement>sections</xmlelement></li>
+              <li>Sections: <xmlelement>section</xmlelement></li>
             </ul>
             <p>These sections are all optional. They can appear in any
               order and can occur multiple times.</p></dd>

--- a/specification/archSpec/technicalContent/rendering-of-abbreviated-form-elements.dita
+++ b/specification/archSpec/technicalContent/rendering-of-abbreviated-form-elements.dita
@@ -21,34 +21,27 @@
         topic.</p>
       <p>The design intent is that processors use the following logic:</p>
     </div>
-    <ol>
-      <li>If the referenced topic is not a
-          <xmlelement>glossentry</xmlelement> topic or a specialization of
-          <xmlelement>glossentry</xmlelement>, the title of the topic <term
-          outputclass="RFC-2119">SHOULD</term> be rendered.</li>
-      <li>
-        <p>If the referenced topic is a <xmlelement>glossentry</xmlelement> topic or a
-          specialization of <xmlelement>glossentry</xmlelement>, processors <term
-            outputclass="RFC-2119">SHOULD</term> render <ph rev="review-a-2024">the
-              <xmlelement>abbreviated-form</xmlelement> element in the following ways:</ph></p>
-        <simpletable relcolwidth="1.0* 3.0*" keycol="1">
-          <strow>
-            <stentry>First usage</stentry>
-            <stentry>Render the contents of the <xmlelement>glossSurfaceForm</xmlelement> elements,
-              if it is not empty. If the <xmlelement>glossSurfaceForm</xmlelement> is empty or does
-              not exist, render the contents of the <xmlelement>glossterm</xmlelement>
-              element.</stentry>
-          </strow>
-          <strow>
-            <stentry>Second and later usage</stentry>
-            <stentry>Render the contents of the <xmlelement>glossAcronym</xmlelement> elements, if
-              it is not empty. If the <xmlelement rev="review-a-2024">glossAcronym</xmlelement> is
-              empty or does not exist, render the contents of the <xmlelement>glossterm</xmlelement>
-              element.</stentry>
-          </strow>
-        </simpletable>
-      </li>
-    </ol>
+    <p>If the referenced topic is not a <xmlelement>glossentry</xmlelement> topic or a
+      specialization of <xmlelement>glossentry</xmlelement>, the title of the topic <term
+        outputclass="RFC-2119">SHOULD</term> be rendered.</p>
+    <p>If the referenced topic is a <xmlelement>glossentry</xmlelement> topic or a specialization of
+        <xmlelement>glossentry</xmlelement>, processors <term outputclass="RFC-2119">SHOULD</term>
+      render <ph rev="review-a-2024">the <xmlelement>abbreviated-form</xmlelement> element in the
+        following ways:</ph></p>
+    <dl>
+      <dlentry>
+        <dt>First usage</dt>
+        <dd>Render the contents of the <xmlelement>glossSurfaceForm</xmlelement> elements, if it is
+          not empty. If the <xmlelement>glossSurfaceForm</xmlelement> is empty or does not exist,
+          render the contents of the <xmlelement>glossterm</xmlelement> element.</dd>
+      </dlentry>
+      <dlentry>
+        <dt>Second and later usage</dt>
+        <dd>Render the contents of the <xmlelement>glossAcronym</xmlelement> elements, if it is not
+          empty. If the <xmlelement rev="review-a-2024">glossAcronym</xmlelement> is empty or does
+          not exist, render the contents of the <xmlelement>glossterm</xmlelement> element.</dd>
+      </dlentry>
+    </dl>
     <p>For an example, see the <xref keyref="elements-abbreviated-form/example">examples</xref> in
       the element-reference topic for the <xmlelement>abbreviated-form</xmlelement> element.</p>
   </conbody>

--- a/specification/archSpec/technicalContent/rendering-of-abbreviated-form-elements.dita
+++ b/specification/archSpec/technicalContent/rendering-of-abbreviated-form-elements.dita
@@ -15,34 +15,33 @@
   </prolog>
     <conbody>
     <div rev="review-a-2024">
-      <p>Consider the following scenario:</p>
-      <p>A DITA publication contains several instances of <xmlelement>abbreviated-form</xmlelement>
-        elements. Each <xmlelement>abbreviated-form</xmlelement> element references the same DITA
-        topic.</p>
+      <!--<p>Consider the following scenario:</p><p>A DITA publication contains several instances of <xmlelement>abbreviated-form</xmlelement> elements. Each <xmlelement>abbreviated-form</xmlelement> element references the same DITA topic.</p>-->
       <p>The design intent is that processors use the following logic:</p>
     </div>
-    <p>If the referenced topic is not a <xmlelement>glossentry</xmlelement> topic or a
-      specialization of <xmlelement>glossentry</xmlelement>, the title of the topic <term
+    <p>When a processor encounters an <xmlelement>abbreviated-form</xmlelement> element that
+      references a DITA topic, if the referenced topic is not a <xmlelement>glossentry</xmlelement>
+      topic or a specialization of <xmlelement>glossentry</xmlelement>, the title of the topic <term
         outputclass="RFC-2119">SHOULD</term> be rendered.</p>
-    <p>If the referenced topic is a <xmlelement>glossentry</xmlelement> topic or a specialization of
-        <xmlelement>glossentry</xmlelement>, processors <term outputclass="RFC-2119">SHOULD</term>
-      render <ph rev="review-a-2024">the <xmlelement>abbreviated-form</xmlelement> element in the
-        following ways:</ph></p>
-    <dl>
-      <dlentry>
-        <dt>First usage</dt>
-        <dd>Render the contents of the <xmlelement>glossSurfaceForm</xmlelement> elements, if it is
-          not empty. If the <xmlelement>glossSurfaceForm</xmlelement> is empty or does not exist,
-          render the contents of the <xmlelement>glossterm</xmlelement> element.</dd>
-      </dlentry>
-      <dlentry>
-        <dt>Second and later usage</dt>
-        <dd>Render the contents of the <xmlelement>glossAcronym</xmlelement> elements, if it is not
-          empty. If the <xmlelement rev="review-a-2024">glossAcronym</xmlelement> is empty or does
-          not exist, render the contents of the <xmlelement>glossterm</xmlelement> element.</dd>
-      </dlentry>
-    </dl>
-    <p>For an example, see the <xref keyref="elements-abbreviated-form/example">examples</xref> in
-      the element-reference topic for the <xmlelement>abbreviated-form</xmlelement> element.</p>
+    <p>When a processor encounters an <xmlelement>abbreviated-form</xmlelement> element that
+      references a DITA topic, if the referenced topic is a <xmlelement>glossentry</xmlelement>
+      topic or a specialization of <xmlelement>glossentry</xmlelement>, processors <term
+        outputclass="RFC-2119">SHOULD</term> render <ph rev="review-a-2024">the
+          <xmlelement>abbreviated-form</xmlelement> element in the following ways:</ph><dl>
+        <dlentry>
+          <dt>First usage</dt>
+          <dd>Render the contents of the <xmlelement>glossSurfaceForm</xmlelement> elements, if it
+            is not empty. If the <xmlelement>glossSurfaceForm</xmlelement> is empty or does not
+            exist, render the contents of the <xmlelement>glossterm</xmlelement> element.</dd>
+        </dlentry>
+        <dlentry>
+          <dt>Second and later usage</dt>
+          <dd>Render the contents of the <xmlelement>glossAcronym</xmlelement> elements, if it is
+            not empty. If the <xmlelement rev="review-a-2024">glossAcronym</xmlelement> is empty or
+            does not exist, render the contents of the <xmlelement>glossterm</xmlelement>
+            element.</dd>
+        </dlentry>
+      </dl></p>
+    <p>See the <xref keyref="elements-abbreviated-form/example">examples</xref> in the
+      element-reference topic for the <xmlelement>abbreviated-form</xmlelement> element.</p>
   </conbody>
 </concept>

--- a/specification/dita-2.0-key-definitions-cover-pages.ditamap
+++ b/specification/dita-2.0-key-definitions-cover-pages.ditamap
@@ -11,14 +11,14 @@
       <!-- Also used in the "Citation format" section.-->
       <topicmeta>
         <keywords>
-          <keyword>Working Draft 17</keyword>
+          <keyword>Working Draft 18</keyword>
         </keywords>
       </topicmeta>
     </keydef>
     <keydef keys="stage-date">
       <topicmeta>
         <keywords>
-          <keyword>01 November 2023</keyword>
+          <keyword>26 March 2024</keyword>
         </keywords>
       </topicmeta>
     </keydef>

--- a/specification/dita-2.0-technical-content-specification.ditamap
+++ b/specification/dita-2.0-technical-content-specification.ditamap
@@ -23,7 +23,7 @@
         <year>2005</year>
       </copyrfirst>
       <copyrlast>
-        <year>2022</year>
+        <year>2024</year>
       </copyrlast>
       <bookowner>
         <organization>OASIS</organization>

--- a/specification/resources/DITA2.0-tc-spec.ditaval
+++ b/specification/resources/DITA2.0-tc-spec.ditaval
@@ -35,6 +35,14 @@
             <alt-text>◄</alt-text>
         </endflag>-->
     </revprop>
+    <revprop action="flag" color="red" val="review-a-2024">
+        <!--        <startflag>
+            <alt-text>►</alt-text>
+        </startflag>
+        <endflag>
+            <alt-text>◄</alt-text>
+        </endflag>-->
+    </revprop>
     <revprop action="flag" color="red" val="review-b">
         <!--        <startflag>
             <alt-text>►</alt-text>

--- a/specification/resources/oasis-cover.dita
+++ b/specification/resources/oasis-cover.dita
@@ -16,10 +16,7 @@
     <section platform="dita-tc-publishing" id="section-3">
       <title>Latest version</title>
       <!--<sl><sli> <xref keyref="oasis-latest-version-html"/> (Authoritative version) </sli><sli><xref keyref="oasis-latest-version-pdf"/></sli></sl>-->
-      <p>You can find the latest version of the draft DITA for Technical
-        Content 2.0 specification in the OASIS document repository. Go to
-        https://www.oasis-open.org/apps/org/workgroup/dita/download.php/70904/latest
-        , and scroll down the page and check for a new revision.</p>
+      <p>N/A</p>
     </section>
     <section conkeyref="reuse-cover/technical-committee"
       ><title/><p/></section>

--- a/specification/resources/oasis-notices.dita
+++ b/specification/resources/oasis-notices.dita
@@ -5,7 +5,7 @@
   <title>Notices</title>
   <refbody>
     <section id="section-1">
-      <p>Copyright © OASIS Open 2020. All Rights Reserved.</p>
+      <p>Copyright © OASIS Open 2024. All Rights Reserved.</p>
       <p>All capitalized terms in the following text have the meanings assigned to them in the OASIS
         Intellectual Property Rights Policy (the "OASIS IPR Policy"). The full <xref
           keyref="oasis-ipr">Policy</xref> may be found at the OASIS website.</p>

--- a/specification/revision-history/revision-history.dita
+++ b/specification/revision-history/revision-history.dita
@@ -132,6 +132,13 @@
             <li>Draft comments from Dawn Stevens in glossary content</li>
           </ul></stentry>
       </strow>
+            <strow>
+                <stentry>18</stentry>
+                <stentry>26 March 2024</stentry>
+                <stentry>Kristen James Eberlein</stentry>
+                <stentry>Contains content updated as part of review of "Glossary entry elements and
+                        <xmlelement>abbreviated-form</xmlelement></stentry>
+            </strow>
         </simpletable>
     </refbody>
 </reference>


### PR DESCRIPTION
Covers the following changes:
- Updates to metadata for working draft 18
- Update copyright date
- Fix rendering of normative statement
- Remove text from cover page pointing to old repo
- Update DITAVAL to include revision marking for latest review