### PR TITLE
Fix CI/CD tests and DITA code samples to pass new validation gate

### DIFF
--- a/.github/gradle/wrapper/gradle-wrapper.properties
+++ b/.github/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/.github/resources/extract-codeblock/xsl/extract.xsl
+++ b/.github/resources/extract-codeblock/xsl/extract.xsl
@@ -107,23 +107,30 @@
     </xsl:result-document>
   </xsl:template>
 
-  <xsl:template match="fragment[concept]" mode="serialize">
+  <xsl:template match="fragment[concept | conbody]" mode="serialize">
     <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Concept//EN"
       doctype-system="concept.dtd">
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>
   </xsl:template>
 
-  <xsl:template match="fragment[task | steps | step]" mode="serialize">
+  <xsl:template match="fragment[task | steps | step | taskbody]" mode="serialize">
     <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Task//EN"
       doctype-system="task.dtd">
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>
   </xsl:template>
 
-  <xsl:template match="fragment[reference]" mode="serialize">
+  <xsl:template match="fragment[reference | refsyn | refbody | properties]" mode="serialize">
     <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Reference//EN"
       doctype-system="reference.dtd">
+      <xsl:apply-templates select="." mode="copy"/>
+    </xsl:result-document>
+  </xsl:template>
+  
+  <xsl:template match="fragment[troubleshooting]" mode="serialize">
+    <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Troubleshooting//EN"
+      doctype-system="troubleshooting.dtd">
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>
   </xsl:template>
@@ -162,10 +169,24 @@
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>
   </xsl:template>
+  
+  <xsl:template match="fragment[glossgroup]" mode="serialize">
+    <xsl:result-document href="{x:createFileName(., '.dita')}"
+      doctype-public="-//OASIS//DTD DITA 2.0 Glossary Group//EN" doctype-system="glossgroup.dtd">
+      <xsl:apply-templates select="." mode="copy"/>
+    </xsl:result-document>
+  </xsl:template>
 
   <xsl:template match="fragment" mode="serialize" priority="0">
     <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Topic//EN"
       doctype-system="topic.dtd">
+      <xsl:apply-templates select="." mode="copy"/>
+    </xsl:result-document>
+  </xsl:template>
+  
+  <xsl:template match="fragment[bookmap | booklists | frontmatter | bookmeta | backmatter | bookrights]" mode="serialize">
+    <xsl:result-document href="{x:createFileName(., '.dita')}"
+      doctype-public="-//OASIS//DTD DITA 2.0 BookMap//EN" doctype-system="bookmap.dtd">
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>
   </xsl:template>

--- a/.github/resources/extract-codeblock/xsl/extract.xsl
+++ b/.github/resources/extract-codeblock/xsl/extract.xsl
@@ -145,7 +145,7 @@
     </xsl:result-document>
   </xsl:template>
 
-  <xsl:template match="fragment[map | topicmeta | topicref | keydef | topicsubject | topicgroup | mapref]" mode="serialize">
+  <xsl:template match="fragment[map | topicmeta | topicref | keydef | topicsubject | topicgroup | mapref | glossref]" mode="serialize">
     <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Map//EN"
       doctype-system="map.dtd">
       <xsl:apply-templates select="." mode="copy"/>

--- a/.github/resources/extract-codeblock/xsl/extract.xsl
+++ b/.github/resources/extract-codeblock/xsl/extract.xsl
@@ -27,6 +27,9 @@
               <xsl:variable name="parsed" select="parse-xml($text)/*[namespace-uri() = '']" as="element()"/>
               <xsl:if test="$parsed">
                 <fragment validate="{not($base = 'ci-xml')}">
+                  <xsl:if test="$base = 'ci-generaltask'">
+                    <xsl:attribute name="task">general</xsl:attribute>
+                  </xsl:if>
                   <xsl:copy-of select="@xtrf | @xtrc"/>
                   <xsl:copy-of select="$parsed"/>
                 </fragment>
@@ -110,6 +113,13 @@
   <xsl:template match="fragment[concept | conbody]" mode="serialize">
     <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Concept//EN"
       doctype-system="concept.dtd">
+      <xsl:apply-templates select="." mode="copy"/>
+    </xsl:result-document>
+  </xsl:template>
+
+  <xsl:template match="fragment[@task = 'general']" priority="10" mode="serialize">
+    <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 General Task//EN"
+      doctype-system="generalTask.dtd">
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>
   </xsl:template>

--- a/.github/resources/extract-codeblock/xsl/extract.xsl
+++ b/.github/resources/extract-codeblock/xsl/extract.xsl
@@ -135,15 +135,8 @@
     </xsl:result-document>
   </xsl:template>
 
-  <xsl:template match="fragment[descendant::topicsubject]" mode="serialize" priority="10">
-    <xsl:result-document href="{x:createFileName(., '.dita')}"
-      doctype-public="-//OASIS//DTD DITA 2.0 Classification Map//EN" doctype-system="classifyMap.dtd">
-      <xsl:apply-templates select="." mode="copy"/>
-    </xsl:result-document>
-  </xsl:template>
-
   <xsl:template match="fragment[map | topicmeta | topicref | keydef | topicsubject | topicgroup | mapref]" mode="serialize">
-    <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Base Map//EN"
+    <xsl:result-document href="{x:createFileName(., '.dita')}" doctype-public="-//OASIS//DTD DITA 2.0 Map//EN"
       doctype-system="map.dtd">
       <xsl:apply-templates select="." mode="copy"/>
     </xsl:result-document>

--- a/.github/settings.gradle
+++ b/.github/settings.gradle
@@ -7,4 +7,4 @@
  * in the user manual at https://docs.gradle.org/7.1.1/userguide/multi_project_builds.html
  */
 
-rootProject.name = 'dita'
+rootProject.name = 'dita-techcomm'

--- a/.github/src/test/java/CatalogTest.java
+++ b/.github/src/test/java/CatalogTest.java
@@ -17,7 +17,7 @@ public class CatalogTest {
         final XMLResolverConfiguration config = new XMLResolverConfiguration(catalog);
 
         final Resolver resolver = new Resolver(config);
-        final InputSource act = resolver.resolveEntity("-//OASIS//DTD DITA 2.0 Base Topic//EN", "foo");
+        final InputSource act = resolver.resolveEntity("-//OASIS//DTD DITA 2.x Task//EN", "foo");
 
         assertNotNull(act.getSystemId());
         assertTrue(act.getByteStream() != null || act.getCharacterStream() != null);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Extract codeblock content
         run: |
           $DITA_HOME/bin/dita \
-            -i $PWD/specification/dita-2.0-specification.ditamap \
-            --filter $PWD/specification/resources/DITA2.0-spec.ditaval \
+            -i $PWD/specification/dita-2.0-technical-content-specification.ditamap \
+            --filter $PWD/specification/baseSpec/resources/DITA2.0-spec.ditaval \
             -f extract-codeblock
       - name: Validate codeblock content
         working-directory: .github

--- a/specification/archSpec/technicalContent/dita-generic-task-topic.dita
+++ b/specification/archSpec/technicalContent/dita-generic-task-topic.dita
@@ -66,7 +66,7 @@
         stylesheets used to generate output produce different labels for
         each of the <xmlelement>prereq</xmlelement> sections, triggered by
         the value of the <xmlatt>outputclass</xmlatt> attribute.</p>
-      <codeblock>&lt;task id="changing_a_tire">
+      <codeblock base="ci-generaltask">&lt;task id="changing_a_tire">
   &lt;title>Changing a tire&lt;/title>
   &lt;taskbody>
     &lt;context>&lt;p>A flat tire typically shows up unexpectedly and catapults itself onto the 

--- a/specification/archSpec/technicalContent/dita-generic-task-topic.dita
+++ b/specification/archSpec/technicalContent/dita-generic-task-topic.dita
@@ -102,7 +102,8 @@
       &lt;/ul>
     &lt;/prereq>
     &lt;steps>
-      &lt;!-- ... -->
+      &lt;step>&lt;cmd>Verify you are in a safe location to change the tire.&lt;/cmd>&lt;/step>
+      &lt;!-- more steps -->
     &lt;/steps>
     &lt;postreq>
       &lt;!-- ... -->

--- a/specification/archSpec/technicalContent/dita-glossarygroup-topic.dita
+++ b/specification/archSpec/technicalContent/dita-glossarygroup-topic.dita
@@ -33,7 +33,7 @@
       &lt;glossdef>An American multinational technology company headquartered in Cupertino, California.&lt;/glossdef>
     &lt;/glossentry>
   <b>&lt;/glossgroup></b>
-  ... (groups B to Y here ) ...
+  &lt;!-- ... (groups B to Y here ) ... -->
   <b>&lt;glossgroup id="glossgroup-z"></b>
     &lt;title>Z&lt;/title>
     &lt;glossentry id="ziziphus-fruit">

--- a/specification/archSpec/technicalContent/dita-spec-intro-bookmap.dita
+++ b/specification/archSpec/technicalContent/dita-spec-intro-bookmap.dita
@@ -56,7 +56,7 @@
       &lt;copyrfirst>
         &lt;year>2020&lt;/year>
       &lt;/copyrfirst>
-      &lt;bookowner>Famous T. Author&lt;/bookowner>
+      &lt;bookowner>&lt;person>Famous T. Author&lt;/person>&lt;/bookowner>
     &lt;/bookrights>
   &lt;/bookmeta>
   <ph rev="review-k">&lt;mapresources>

--- a/specification/archSpec/technicalContent/dita-spec-intro-bookmap.dita
+++ b/specification/archSpec/technicalContent/dita-spec-intro-bookmap.dita
@@ -56,6 +56,7 @@
       &lt;copyrfirst>
         &lt;year>2020&lt;/year>
       &lt;/copyrfirst>
+      &lt;bookowner>Famous T. Author&lt;/bookowner>
     &lt;/bookrights>
   &lt;/bookmeta>
   <ph rev="review-k">&lt;mapresources>

--- a/specification/langRef/technicalContent/bookchangehistory.dita
+++ b/specification/langRef/technicalContent/bookchangehistory.dita
@@ -33,14 +33,14 @@
       &lt;completed>&lt;year>2020&lt;/year>&lt;month>01&lt;/month>&lt;/completed>
     &lt;/reviewed>
     &lt;edited>
-      &lt;revisionid>1&lt;/revisionid>
       &lt;person>Joe T. Editor&lt;/person>
+      &lt;revisionid>1&lt;/revisionid>
       &lt;completed>&lt;year>2019&lt;/year>&lt;month>03&lt;/month>&lt;day>15&lt;/day>&lt;/completed>
       &lt;summary>Corrected grammatical errors.&lt;/summary>
     &lt;/edited>
     &lt;edited>
-      &lt;revisionid>3&lt;/revisionid>
       &lt;person>Joe T. Editor&lt;/person>
+      &lt;revisionid>3&lt;/revisionid>
       &lt;completed>&lt;year>2022&lt;/year>&lt;month>06&lt;/month>&lt;day>30&lt;/day>&lt;/completed>
     &lt;/edited>
     &lt;tested>

--- a/specification/langRef/technicalContent/change-request-id.dita
+++ b/specification/langRef/technicalContent/change-request-id.dita
@@ -33,6 +33,7 @@
       &lt;change-request-system>example.com/my/queue/&lt;/change-request-system>
       <b>&lt;change-request-id>TCKT-1313&lt;/change-request-id></b>
     &lt;/change-request-reference>
+    &lt;change-completed>2026-03-19&lt;/change-completed>
   &lt;/change-item>
 &lt;/change-historylist></codeblock>
     </example>

--- a/specification/langRef/technicalContent/change-request-reference.dita
+++ b/specification/langRef/technicalContent/change-request-reference.dita
@@ -36,6 +36,7 @@
         &lt;change-request-system>example.com/my/queue/&lt;/change-request-system>
         &lt;change-request-id>TCKT-1313&lt;/change-request-id>
       <b>&lt;/change-request-reference></b>
+      &lt;change-completed>2025-10-31&lt;/change-completed>
     &lt;/change-item>
   &lt;/change-historylist></codeblock>
     </example>

--- a/specification/langRef/technicalContent/change-request-system.dita
+++ b/specification/langRef/technicalContent/change-request-system.dita
@@ -34,6 +34,7 @@
         <b>&lt;change-request-system>example.com/my/queue/&lt;/change-request-system></b>
         &lt;change-request-id>TCKT-1313&lt;/change-request-id>
       &lt;/change-request-reference>
+      &lt;change-completed>2026-03-19&lt;/change-completed>
     &lt;/change-item>
   &lt;/change-historylist></codeblock>
     </example>

--- a/specification/langRef/technicalContent/edited.dita
+++ b/specification/langRef/technicalContent/edited.dita
@@ -37,13 +37,13 @@
       &lt;completed>&lt;year>2020&lt;/year>&lt;month>01&lt;/month>&lt;/completed>
     &lt;/reviewed>
    <b>&lt;edited></b>
-      &lt;revisionid>1&lt;/revisionid>
       &lt;person>Joe T. Editor&lt;/person>
+      &lt;revisionid>1&lt;/revisionid>
       &lt;completed>&lt;year>2020&lt;/year>&lt;month>03&lt;/month>&lt;day>15&lt;/day>&lt;/completed>
     <b>&lt;/edited></b>
     <b>&lt;edited></b>
-      &lt;revisionid>2&lt;/revisionid>
       &lt;person>Joe T. Editor&lt;/person>
+      &lt;revisionid>2&lt;/revisionid>
       &lt;completed>&lt;year>2023&lt;/year>&lt;month>06&lt;/month>&lt;day>30&lt;/day>&lt;/completed>
     <b>&lt;/edited></b>
   &lt;/bookchangehistory>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -132,7 +132,7 @@
 &lt;/equation-block></codeblock>
         <p>The <filepath>mathml-equation-library.xml</filepath> file
           contains the following content:</p>
-        <codeblock>&lt;?xml version="1.0" encoding="UTF-8"?>
+        <codeblock base="ci-xml">&lt;?xml version="1.0" encoding="UTF-8"?>
 &lt;root>
   &lt;part>
     &lt;math id="timeinday" xmlns="http://www.w3.org/1998/Math/MathML">

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -42,7 +42,7 @@
           way:</p>
         <codeblock>&lt;keydef keys="math-fragment-0002" href="mathml/mathml-library.xml#math-fragment-02"/></codeblock>
         <p>You reference this key by using just the key name:</p>
-        <codeblock>&lt;mathref <b>keyref="math-fragment-0002"</b>/></codeblock>
+        <codeblock>&lt;mathmlref <b>keyref="math-fragment-0002"</b>/></codeblock>
       </div>
     </section>
     <section id="processing-expectations">

--- a/specification/langRef/technicalContent/postreq.dita
+++ b/specification/langRef/technicalContent/postreq.dita
@@ -20,12 +20,13 @@
       <title>Example</title>
       <p>The following code sample shows how a user might be directed to
         notify a test proctor after completing a test.</p>
-      <codeblock>&lt;steps>
-&lt;!-- ... -->
-  &lt;step>
-    &lt;cmd>Click &lt;uicontrol>Done&lt;/uicontrol> to complete the test.&lt;/cmd>
-  &lt;/step>
-&lt;/steps>
-<b>&lt;postreq&gt;</b>Notify the proctor upon completing this self-test.<b>&lt;/postreq&gt;</b> 
-</codeblock>
+      <codeblock>&lt;taskbody>
+  &lt;steps>
+    &lt;!-- ... -->
+    &lt;step>
+      &lt;cmd>Click &lt;uicontrol>Done&lt;/uicontrol> to complete the test.&lt;/cmd>
+    &lt;/step>
+  &lt;/steps>
+  <b>&lt;postreq&gt;</b>Notify the proctor upon completing this self-test.<b>&lt;/postreq&gt;</b> 
+&lt;/taskbody></codeblock>
     </example></refbody></reference>

--- a/specification/langRef/technicalContent/revisionid.dita
+++ b/specification/langRef/technicalContent/revisionid.dita
@@ -45,13 +45,13 @@
   &lt;/publisherinformation>
   &lt;bookchangehistory>
     &lt;edited>
-      <b>&lt;revisionid>1&lt;/revisionid></b>
       &lt;person>Joe T. Editor&lt;/person>
+      <b>&lt;revisionid>1&lt;/revisionid></b>
       &lt;completed>&lt;year>2020&lt;/year>&lt;month>03&lt;/month>&lt;day>15&lt;/day>&lt;/completed>
     &lt;/edited>
     &lt;edited>
-      <b>&lt;revisionid>2&lt;/revisionid></b>
       &lt;person>Joe T. Editor&lt;/person>
+      <b>&lt;revisionid>2&lt;/revisionid></b>
       &lt;completed>&lt;year>2023&lt;/year>&lt;month>06&lt;/month>&lt;day>30&lt;/day>&lt;/completed>
     &lt;/edited>
   &lt;/bookchangehistory>

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -93,11 +93,10 @@
     <b>&lt;svgref href="media/svg/svg-graphic-01.xml"/></b>
   &lt;/svg-container>
 &lt;/fig></codeblock>
-        <p>The <filepath>svg-graphic-01.xml</filepath> file contains the
-          following content. Note that the <xmlelement>svg</xmlelement>
-          element sets the SVG namespace as the default namespace, so there
-          are no namespace prefixes on the SVG
-          markup.<codeblock>&lt;?xml version="1.0" encoding="UTF-8"?>
+        <p>The <filepath>svg-graphic-01.xml</filepath> file contains the following content. Note
+          that the <xmlelement>svg</xmlelement> element sets the SVG namespace as the default
+          namespace, so there are no namespace prefixes on the SVG
+          markup.<codeblock base="ci-xml">&lt;?xml version="1.0" encoding="UTF-8"?>
 &lt;svg <b>xmlns="http://www.w3.org/2000/svg"</b> width="100" height="100">
   &lt;defs>
     &lt;filter id="f1" x="0" y="0">
@@ -120,9 +119,8 @@
     <b>&lt;svgref href="media/svg/svg-library.xml#frag-0001" /></b>
   &lt;/svg-container>
 &lt;/fig></codeblock>
-        <p>The <filepath>svg-library.xml</filepath> file contains the
-          following
-          content:<codeblock>&lt;?xml version="1.0" encoding="UTF-8"?>
+        <p>The <filepath>svg-library.xml</filepath> file contains the following
+          content:<codeblock base="ci-xml">&lt;?xml version="1.0" encoding="UTF-8"?>
 &lt;root>
   &lt;part>
     &lt;svg <b>id="frag-0001"</b> xmlns="http://www.w3.org/2000/svg" width="100" height="100">

--- a/specification/langRef/technicalContent/synblk.dita
+++ b/specification/langRef/technicalContent/synblk.dita
@@ -43,9 +43,9 @@
   &lt;title>Request file listing&lt;/title>
   &lt;groupseq>
     &lt;kwd>clicmd&lt;/kwd>
-    <b>&lt;synblk conkeyref="syntax-library/profileopts"/></b>
-    &lt;groupcomp>&lt;oper>--&lt;/oper>&lt;kwd>filelist&lt;/kwd>&lt;sep>=&lt;/sep>&lt;var>volumeid&lt;/var>&lt;/groupcomp>
   &lt;/groupseq>
+  <b>&lt;synblk conkeyref="syntax-library/profileopts"/></b>
+  &lt;groupcomp>&lt;oper>--&lt;/oper>&lt;kwd>filelist&lt;/kwd>&lt;sep>=&lt;/sep>&lt;var>volumeid&lt;/var>&lt;/groupcomp>
 &lt;/syntaxdiagram></codeblock></p></example>
   </refbody>
 </reference>

--- a/specification/langRef/technicalContent/taskbody.dita
+++ b/specification/langRef/technicalContent/taskbody.dita
@@ -80,6 +80,7 @@
       &lt;/ul>
     &lt;/section>
     &lt;steps>
+      &lt;step>&lt;cmd>Read all instructions before you begin.&lt;/cmd>&lt;/step>
       &lt;!-- ... -->
     &lt;/steps>
   <b>&lt;/taskbody></b>

--- a/specification/langRef/technicalContent/taskbody.dita
+++ b/specification/langRef/technicalContent/taskbody.dita
@@ -44,7 +44,7 @@
     &lt;context>As you perform this procedure, you can select the conventions that you want to 
              use for file names.&lt;/context>
     &lt;steps>
-      &lt;!-- ... -->
+      &lt;step>&lt;cmd>&lt;!-- ... -->&lt;/cmd>&lt;/step>
     &lt;/steps>
     &lt;result>In the File Manager view, you can see the file names and paths of the DITA
             topics.&lt;/result>
@@ -64,7 +64,7 @@
         <p>The following code sample shows how the
             <xmlelement>taskbody</xmlelement>element contains building
           blocks of a general task topic:</p>
-        <codeblock>&lt;task id="completing-group-project">
+        <codeblock base="ci-generaltask">&lt;task id="completing-group-project">
   &lt;title>Completing the final project&lt;/title>
   &lt;shortdesc>This handout contains information about completing the final project 
       for History 275, "Exploring your community history."&lt;/shortdesc>
@@ -101,7 +101,7 @@
           general task topic for a reuse topic enables them to have
           multiple <xmlelement>prereq</xmlelement> elements in a single
           topic.</p>
-        <codeblock>&lt;task id="reuse-prereq">
+        <codeblock base="ci-generaltask">&lt;task id="reuse-prereq">
   &lt;title>Reuse topic: &lt;xmlelement>prereq&lt;/xmlelement>&lt;/title>
   &lt;shortdesc>This topic stores &lt;xmlelement>prereq&lt;/xmlelement> elements
              that are reused in the product documentation.&lt;/shortdesc>

--- a/specification/langRef/technicalContent/troubleSolution.dita
+++ b/specification/langRef/technicalContent/troubleSolution.dita
@@ -58,8 +58,8 @@
   &lt;title>E247: Memory fault has occurred&lt;/title>
   &lt;troublebody>
     <b>&lt;troubleSolution></b>
-      &lt;cause>The &lt;msgnum>E247&lt;/msgnum> error message is generated due to a
-           transient memory fault.&lt;/cause>
+      &lt;cause>&lt;p>The &lt;msgnum>E247&lt;/msgnum> error message is generated due to a
+           transient memory fault.&lt;/p>&lt;/cause>
       &lt;remedy>
         &lt;steps>
           &lt;step>&lt;cmd>Reset the alarm.&lt;/cmd>&lt;/step>

--- a/specification/langRef/technicalContent/xmlnsname.dita
+++ b/specification/langRef/technicalContent/xmlnsname.dita
@@ -35,7 +35,7 @@
           <xmlelement>xmlnsname</xmlelement> element can be used to tag the
         namespace for SVG:</p>
       <codeblock>&lt;p>SVG markup is specified in an &lt;xmlelement>svg&lt;/xmlelement> element with
-the namespace <b>&lt;xmlnamespace>http://www.w3.org/2000/svg&lt;/xmlnamespace></b>.&lt;/p></codeblock>
+the namespace <b>&lt;xmlnsname>http://www.w3.org/2000/svg&lt;/xmlnsname></b>.&lt;/p></codeblock>
     </example>
   </refbody>
 </reference>


### PR DESCRIPTION
Fix the newly added github action

The action was created initially by @jelovirt to validate the base spec. This uses the same logic for the technical communication spec. The update requires a few changes to the CI/CD code itself, and numerous updates to examples within this spec so that they pass validation.