### PR TITLE
Set up test to validate DTD / RNG equivalence

### DIFF
--- a/.github/gradle/wrapper/gradle-wrapper.properties
+++ b/.github/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,52 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Set up JDK 1.17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
+      - name: Compare DTD and Relax NG grammar reports
+        run: |
+          set -e
+          mkdir -p build/grammar-compare/classes build/grammar-compare/reports
+          javac -d build/grammar-compare/classes \
+            specification/baseSpec/.github/resources/DtdToJson.java \
+            specification/baseSpec/.github/resources/RngToJson.java
+
+          compare_grammar_pair() {
+            name="$1"
+            dtd_path="$2"
+            rng_path="$3"
+            dtd_json="build/grammar-compare/reports/${name}-dtd.json"
+            rng_json="build/grammar-compare/reports/${name}-rng.json"
+
+            java -cp build/grammar-compare/classes DtdToJson \
+              --catalog doctypes/catalog.xml \
+              --catalog specification/baseSpec/doctypes/catalog.xml \
+              -o "$dtd_json" \
+              "$dtd_path"
+            java -cp build/grammar-compare/classes RngToJson \
+              --catalog doctypes/catalog.xml \
+              --catalog specification/baseSpec/doctypes/catalog.xml \
+              -o "$rng_json" \
+              "$rng_path"
+            python3 specification/baseSpec/.github/resources/compare_json_reports.py \
+              "$dtd_json" \
+              "$rng_json" \
+              --quiet
+          }
+
+          compare_grammar_pair bookmap \
+            doctypes/dtd/bookmap/bookmap.dtd \
+            doctypes/rng/bookmap/bookmap.rng
+
+          for name in concept ditabase generalTask glossentry glossgroup map reference task topic troubleshooting; do
+            compare_grammar_pair "$name" \
+              "doctypes/dtd/technicalContent/${name}.dtd" \
+              "doctypes/rng/technicalContent/${name}.rng"
+          done
       - name: Cache DITA-OT
         uses: actions/cache@v4
         with:

--- a/doctypes/rng/technicalContent/ditabase.rng
+++ b/doctypes/rng/technicalContent/ditabase.rng
@@ -141,6 +141,7 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Composite//EN"
       <define name="dita.attlist" combine="interleave">
         <ref name="arch-atts"/>
         <ref name="localization-atts" dita:since="DITA 1.3"/>
+        <ref name="specializations-att"/>
       </define>
 
   </div>


### PR DESCRIPTION
Use the updated build scripts from https://github.com/oasis-tcs/dita/pull/976 to verify that tech comm grammars are equivalent between DTD and RNG. If they are not, the pull request build will fail.