### PR TITLE
Fix missing attribute in list for glossref

### DIFF
--- a/specification/langRef/technicalContent/glossref.dita
+++ b/specification/langRef/technicalContent/glossref.dita
@@ -36,6 +36,7 @@
           keyref="attributes-common/attr-chunk"><xmlatt>chunk</xmlatt></xref>, <xref
           keyref="attributes-common/attr-collection-type"><xmlatt>collection-type</xmlatt></xref>,
           <xref keyref="attributes-common/attr-keyref"><xmlatt>keyref</xmlatt></xref>, <xref
+          keyref="attributes-common/attr-keys"><xmlatt>keys</xmlatt></xref>, <xref
           keyref="attributes-common/attr-linking"><xmlatt>linking</xmlatt></xref>, <xref
           keyref="attributes-common/attr-processing-role"><xmlatt>processing-role</xmlatt></xref>,
           <xref keyref="attributes-common/attr-search"><xmlatt>search</xmlatt></xref>, and <xref


### PR DESCRIPTION
The `glossref` element requires `@keys`, but that attribute was not listed as one of the available attributes (even though it was listed later as required). This fixes the list to include `@keys`