### PR TITLE
Fix example for bookeventtype

### DIFF
--- a/specification/langRef/technicalContent/bookeventtype.dita
+++ b/specification/langRef/technicalContent/bookeventtype.dita
@@ -36,7 +36,7 @@
 &lt;bookmeta>
    &lt;bookchangehistory>
       &lt;bookevent>
-         <b>&lt;bookeventtype name="indexed"/></b>
+         <b>&lt;bookeventtype value="indexed"/></b>
           &lt;completed>&lt;month>09&lt;/month>&lt;year>2022&lt;/year>&lt;/completed>
       &lt;/bookevent>
    &lt;/bookchangehistory>


### PR DESCRIPTION
The element description says to use `@value` to specify the event type, but the example uses `@name`. This updates the example to match the element description.