### PR TITLE
Replace TBD with a section overview for topic and map elements

### DIFF
--- a/specification/langRef/topic-and-map-specializations.dita
+++ b/specification/langRef/topic-and-map-specializations.dita
@@ -2,5 +2,7 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA 2.x Reference//EN" "reference.dtd">
 <reference id="topic-and-map-specializations">
     <title>Topic and map specializations</title>
-    <shortdesc>Content TBD</shortdesc>
+    <shortdesc>Topic and map specializations in the technical content specification include several
+        structural specializations, such as the concept, task, and reference information
+        types.</shortdesc>
 </reference>


### PR DESCRIPTION
Replaces "Content TBD" with a short description that describes this section of the specification.