### PR TITLE
Fix bad xmlelement markup

### DIFF
--- a/specification/archSpec/technicalContent/TroubleshootingElements.dita
+++ b/specification/archSpec/technicalContent/TroubleshootingElements.dita
@@ -27,12 +27,11 @@
       <p>Troubleshooting information can be added following a step in a procedure if it is likely
         that the user will encounter a problem in performing the step.</p>
       <p>The <xmlelement>steptroubleshooting</xmlelement> element can occur following the
-          <xmlelement>cmd</xmlelement> element in the <xmlelement>step</xmlelement> or
-          <xmlelement>substep</xmlelement> element. The
-        <xmlelement>steptroubleshooting</xmlelement>element ends the <xmlelement>step</xmlelement>
-        or <xmlelement>substep</xmlelement> element. Another element, such as
-          <xmlelement>info</xmlelement> or <xmlelement>stepxmp</xmlelement>, cannot be added after
-        the <xmlelement>steptroubleshooting</xmlelement> element.</p>
+          <xmlelement>cmd</xmlelement> element in the <xmlelement>step</xmlelement> element. The
+          <xmlelement>steptroubleshooting</xmlelement>element ends the <xmlelement>step</xmlelement>
+        element. Another element, such as <xmlelement>info</xmlelement> or
+          <xmlelement>stepxmp</xmlelement>, cannot be added after the
+          <xmlelement>steptroubleshooting</xmlelement> element.</p>
       <p>The first example shows troubleshooting information added to a step. The second example
         shows the troubleshooting information following a step result.</p>
       <codeblock>&lt;step>
@@ -63,7 +62,7 @@
         in correcting a problem that might have occurred. The
           <xmlelement>tasktroubleshooting</xmlelement> element is one of four optional elements that
         can follow the <xmlelement>steps</xmlelement> element. When these optional element are used,
-        they must appear in the following order: <xmlelement>results</xmlelement>,
+        they must appear in the following order: <xmlelement>result</xmlelement>,
           <xmlelement>tasktroubleshooting</xmlelement>, <xmlelement>example</xmlelement>, and
           <xmlelement>postreq</xmlelement>.</p>
       <codeblock>&lt;steps>

--- a/specification/archSpec/technicalContent/dita-generic-task-topic.dita
+++ b/specification/archSpec/technicalContent/dita-generic-task-topic.dita
@@ -19,7 +19,7 @@
           <dd>This portion of the topic can contain the following
             structural sections:<ul>
               <li>Prerequisites: <xref keyref="elements-prereq"
-                    ><xmlelement>prerequisites</xmlelement></xref></li>
+                  ><xmlelement>prereq</xmlelement></xref></li>
               <li>Contextual information: <xref keyref="elements-context"
                     ><xmlelement>context</xmlelement></xref></li>
               <li>Sections: <xmlelement>section</xmlelement></li>
@@ -48,9 +48,8 @@
                   keyref="elements-tasktroubleshooting"
                     ><xmlelement>tasktroubleshooting</xmlelement></xref></li>
               <li>Example: <xmlelement>example</xmlelement></li>
-              <li><ph rev="review-a">What to do next</ph>: <xref
-                  keyref="elements-postreq"
-                    ><xmlelement>postreq)</xmlelement></xref></li>
+              <li><ph rev="review-a">What to do next</ph>: <xref keyref="elements-postreq"
+                    ><xmlelement>postreq</xmlelement></xref></li>
             </ol><p>While all of the above structural components are
               optional, they must occur in the outlined order. Examples and
               post-requisites can occur multiple times.</p></dd>

--- a/specification/archSpec/technicalContent/dita-glossary-topic.dita
+++ b/specification/archSpec/technicalContent/dita-glossary-topic.dita
@@ -59,7 +59,7 @@
           glossary entry topic. On the first usage of <codeph>&lt;abbreviated-form
             keyref="aids"/></codeph>, the processor renders the content of the
             <xmlelement>glossSurfaceForm</xmlelement> element. On the second and later usages, the
-          processor renders the content of the <xmlelement>glossAcronum</xmlelement> element.</p>
+          processor renders the content of the <xmlelement>glossAcronym</xmlelement> element.</p>
       </fig>
     </example>
   </conbody>

--- a/specification/archSpec/technicalContent/dita-task-topic.dita
+++ b/specification/archSpec/technicalContent/dita-task-topic.dita
@@ -22,7 +22,7 @@
               structural sections:</p>
             <ol>
               <li>Prerequisites: <xref keyref="elements-prereq"
-                    ><xmlelement>prerequisites</xmlelement></xref></li>
+                  ><xmlelement>prereq</xmlelement></xref></li>
               <li>Contextual information: <xref keyref="elements-context"
                     ><xmlelement>context</xmlelement></xref></li>
             </ol>
@@ -49,9 +49,8 @@
                   keyref="elements-tasktroubleshooting"
                     ><xmlelement>tasktroubleshooting</xmlelement></xref></li>
               <li>Example: <xmlelement>example</xmlelement></li>
-              <li><ph rev="review-a">What to do next</ph>: <xref
-                  keyref="elements-postreq"
-                    ><xmlelement>postreq)</xmlelement></xref></li>
+              <li><ph rev="review-a">What to do next</ph>: <xref keyref="elements-postreq"
+                    ><xmlelement>postreq</xmlelement></xref></li>
             </ol><p>These sections are all optional, but they must occur in
               the outlined order.</p></dd>
         </dlentry>

--- a/specification/archSpec/technicalContent/releaseManagement-domain.dita
+++ b/specification/archSpec/technicalContent/releaseManagement-domain.dita
@@ -19,23 +19,18 @@
         <!--<image scale="80" placement="break" keyref="images-relmgmt-d"><alt>Tree structure diagram that shows the elements that are available in the release management domain, their relationships to each other, and where they can be used in a DITA topic. The <xmlelement>change-historylist</xmlelement> element can appear in the prolog and can contain <xmlelement>change-items</xmlelement>. The following elements are children of <xmlelement>change-item</xmlelement>: <xmlelement>change-person</xmlelement>, <xmlelement>change-organization</xmlelement>, <xmlelement>change-revisionid</xmlelement>, <xmlelement>change-request-reference</xmlelement>, <xmlelement>change-started</xmlelement>, <xmlelement>change-summary</xmlelement>, and <xmlelement>data</xmlelement>. The <xmlelement>change-request-reference</xmlelement> element can have children <xmlelement>change-request-system</xmlelement> and <xmlelement>change-request-id</xmlelement>. </alt></image>--> 
 		  <image scale="80" placement="break"
           href="../../images/ReleaseManagementElements.png">
-          <alt>Tree structure diagram that shows the elements that are
-            available in the release management domain, their relationships
-            to each other, and where they can be used in a DITA topic. The
-              <xmlelement>change-historylist</xmlelement> element can
-            appear in the prolog and can contain
-              <xmlelement>change-items</xmlelement>. The following elements
-            are children of <xmlelement>change-item</xmlelement>:
-              <xmlelement>change-person</xmlelement>,
-              <xmlelement>change-organization</xmlelement>,
+          <alt>Tree structure diagram that shows the elements that are available in the release
+            management domain, their relationships to each other, and where they can be used in a
+            DITA topic. The <xmlelement>change-historylist</xmlelement> element can appear in the
+            prolog and can contain <xmlelement>change-item</xmlelement>. The following elements are
+            children of <xmlelement>change-item</xmlelement>:
+            <xmlelement>change-person</xmlelement>, <xmlelement>change-organization</xmlelement>,
               <xmlelement>change-revisionid</xmlelement>,
               <xmlelement>change-request-reference</xmlelement>,
-              <xmlelement>change-started</xmlelement>,
-              <xmlelement>change-summary</xmlelement>, and
-              <xmlelement>data</xmlelement>. The
-              <xmlelement>change-request-reference</xmlelement> element can
-            have children <xmlelement>change-request-system</xmlelement>
-            and <xmlelement>change-request-id</xmlelement>. </alt>
+              <xmlelement>change-started</xmlelement>, <xmlelement>change-summary</xmlelement>, and
+              <xmlelement>data</xmlelement>. The <xmlelement>change-request-reference</xmlelement>
+            element can have children <xmlelement>change-request-system</xmlelement> and
+              <xmlelement>change-request-id</xmlelement>. </alt>
         </image> 
 		</fig> 
 		<p>The following list provides a brief description of the elements:</p> 

--- a/specification/html.sh
+++ b/specification/html.sh
@@ -1,0 +1,2 @@
+~/dita-ot-4.4/bin/dita install
+~/dita-ot-4.4/bin/dita -i dita-2.0-technical-content-specification.ditamap -f spec-html5 -o out --filter=resources/DITA2.0-tc-spec.ditaval -t ../temp -Dclean.temp=no 

--- a/specification/langRef/technicalContent/abbreviated-form.dita
+++ b/specification/langRef/technicalContent/abbreviated-form.dita
@@ -70,7 +70,7 @@
           important elements:</p>
         <dl>
           <dlentry>
-            <dt><xmlelement>glossSurfaceform</xmlelement></dt>
+            <dt><xmlelement>glossSurfaceForm</xmlelement></dt>
             <dd>Defines the term as it should be rendered <ph rev="review-a-2024">on first use</ph>.
               Typically this is the long form of a term, followed by an abbreviation or acronym.
               Note that other languages often do not follow the same conventions as English.</dd>
@@ -109,7 +109,7 @@ many find an <b>&lt;abbreviated-form keyref="abs"/></b> useful.
 &lt;/section></codeblock>
       </fig>
       <p>The typical rendering is that the first use of the
-          <xmlelement>abbreviated-form keyref="ab"</xmlelement> will result
+          <codeph>&lt;abbreviated-form keyref="ab"/&gt;</codeph> will result
         in the surface form of the term, while subsequent usages will
         result in the acronym, as shown in the following screen
         capture:</p>

--- a/specification/langRef/technicalContent/approved.dita
+++ b/specification/langRef/technicalContent/approved.dita
@@ -17,7 +17,7 @@
     <refbody>
         <section id="usage-information" rev="review-j">
             <title>Usage information</title>
-            <p>Information within <xmlelement>approval</xmlelement> can apply to different aspects
+            <p>Information within <xmlelement>approved</xmlelement> can apply to different aspects
                 of the map, such as approval of the overall content or of a specific deliverable
                 created from the map.</p>
         </section>

--- a/specification/langRef/technicalContent/choption.dita
+++ b/specification/langRef/technicalContent/choption.dita
@@ -8,11 +8,9 @@
         <indexterm>choice tables<indexterm>options</indexterm></indexterm><indexterm><xmlelement>choption</xmlelement></indexterm><indexterm>task elements<indexterm><xmlelement>choption</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>
-      <p>Unless the <xmlatt>keycol</xmlatt> attribute on the
-          <xmlelement>choicetable</xmlelement> element is set to
-          <keyword>0</keyword>, the contents of the
-          <xmlelement>choiceoption</xmlelement> element is typically
-        rendered in a bold font.</p>
+      <p>Unless the <xmlatt>keycol</xmlatt> attribute on the <xmlelement>choicetable</xmlelement>
+        element is set to <keyword>0</keyword>, the contents of the
+          <xmlelement>choption</xmlelement> element is typically rendered in a bold font.</p>
     </section>
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>

--- a/specification/non-normative/elementsMerged.dita
+++ b/specification/non-normative/elementsMerged.dita
@@ -25,7 +25,7 @@
           part of that segment. Whenever possible, such elements should be placed only at sentence
           boundaries in order to aid translation. The subflow elements in base DITA are
             <xmlelement>draft-comment</xmlelement>, <xmlelement>fn</xmlelement>,
-            <xmlelement>idex-see</xmlelement>, <xmlelement>index-see-also</xmlelement>,
+            <xmlelement>index-see</xmlelement>, <xmlelement>index-see-also</xmlelement>,
             <xmlelement>indexterm</xmlelement>, and <xmlelement>required-cleanup</xmlelement></li>
         <li>The <xmlelement>keyword</xmlelement> element (as well as specializations of
             <xmlelement>keyword</xmlelement>) is an inline, phrase-like element when it appears in
@@ -581,7 +581,7 @@
           <stentry/>
         </strow>
         <strow>
-          <stentry><xmlelement>glossbody</xmlelement></stentry>
+          <stentry><xmlelement>glossBody</xmlelement></stentry>
           <stentry><xmlelement>body</xmlelement>, <xmlelement>conbody</xmlelement></stentry>
           <stentry>yes</stentry>
           <stentry>block</stentry>


### PR DESCRIPTION
Fixes several instances of `xmlelement` that had the wrong XML element name