### PR TITLE
Use dita element from base vocab oasis-tcs/dita#952

### DIFF
--- a/doctypes/dtd/technicalContent/ditabase.dtd
+++ b/doctypes/dtd/technicalContent/ditabase.dtd
@@ -257,12 +257,6 @@
 >
 
 <!-- ============================================================= -->
-<!--                    LOCALLY DEFINED CONTAINMENT                -->
-<!-- ============================================================= -->
-
-<!ELEMENT dita          (%info-types;)+                              >  
-
-<!-- ============================================================= -->
 <!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
 <!-- ============================================================= -->
 
@@ -413,12 +407,15 @@
          "xmlDomain.mod"
 >%xml-d-def;
 
-<!ATTLIST dita
-              specializations 
-                        CDATA                            
-                                  "&included-domains;"
-              %arch-atts;
-              %localization-atts;
->
+<!-- ============================================================= -->
+<!--                    INTEGRATE THE DITA ELEMENT FOR             -->
+<!--                    USE WITH DITABASE COMPOSITE DOCTYPE        -->
+<!-- ============================================================= -->
+
+<!ENTITY % ditaElement-def
+  PUBLIC "-//OASIS//ELEMENT DITA 2.x Element//EN"
+         "ditaelement.mod"
+>%ditaElement-def;
 
 <!-- ================= End of DITA BASE ================= -->
+

--- a/doctypes/rng/technicalContent/ditabase.rng
+++ b/doctypes/rng/technicalContent/ditabase.rng
@@ -125,25 +125,8 @@ PUBLIC "-//OASIS//DTD DITA 2.0 Composite//EN"
       <include href="xmlDomain.rng" dita:since="1.3"/>
   </div>
   <div>
-      <a:documentation>Define a containment for topics for editor support </a:documentation>
-      <define name="dita.element">
-         <element name="dita">
-            <a:documentation>The &lt;dita&gt; element provides a top-level container for multiple topics when you create documents using the ditabase document type. The &lt;dita&gt; element lets you create any
-          sequence of concept, task, and reference topics, and the ditabase document type lets you further nest these topic types inside each other. The &lt;dita&gt; element has no particular output
-          implications; it simply allows you to create multiple topics of different types at the same level in a single document. Category: Ditabase document type</a:documentation>
-            <ref name="dita.attlist"/>
-            <oneOrMore>
-               <ref name="info-types"/>
-            </oneOrMore>
-         </element>
-      </define>
-
-      <define name="dita.attlist" combine="interleave">
-        <ref name="arch-atts"/>
-        <ref name="localization-atts" dita:since="DITA 1.3"/>
-        <ref name="specializations-att"/>
-      </define>
-
+      <a:documentation>Import the dita container element</a:documentation>
+      <include href="urn:pubid:oasis:names:tc:dita:rng:ditaelement.rng:2.0"/>
   </div>
   <div>
       <a:documentation>ID-DEFINING-ELEMENT OVERRIDES</a:documentation>


### PR DESCRIPTION
Update DTD and RNG to use the new module that defines `<dita>` within the base spec, added with https://github.com/oasis-tcs/dita/pull/996