### PR TITLE
Resolving draft comments

### DIFF
--- a/specification/langRef/containers/SVG-elements.dita
+++ b/specification/langRef/containers/SVG-elements.dita
@@ -17,7 +17,6 @@
   </prolog>
   <refbody>
     <section id="section-1">
-      <!--<draft-comment author="nancylph" time="21 may 2021"><p>The MathML and SVG domains are unusual enough that I wonder if we might need to leave this information in the language reference, or can it just be in the architecture spec? And I took out the reference to XSD, since we're no longer providing it. </p></draft-comment>-->
       <p>For SVG markup that is stored directly in DITA documents that are validated using DTDs, the
         SVG elements must use a namespace prefix in order to avoid conflict with DITA-defined
         elements of the same name. Documents validated using RELAX NG can default the SVG namespace

--- a/specification/langRef/technicalContent/booknumber.dita
+++ b/specification/langRef/technicalContent/booknumber.dita
@@ -3,13 +3,8 @@
  "reference.dtd">
 <reference id="booknumber" xml:lang="en-us">
   <title><xmlelement>booknumber</xmlelement></title>
-  <shortdesc>The <xmlelement>booknumber</xmlelement> element contains the number used to identify a
-    book that is part of a collection of works that belong to the same author.<draft-comment
-      author="tammy">The original description states that &lt;booknumber> is the "book's form
-      number" while the original examples states that that it "is a number that identifies this book
-      among all of the author's works". As noted in the current short description, I opted to go
-      with the latter definition. However, I don't actually know if either is accurate. It's not an
-      element I've ever had the need to use.</draft-comment></shortdesc>
+  <shortdesc>The <xmlelement>booknumber</xmlelement> element contains a number used to identify a
+    book.</shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/specification/langRef/technicalContent/bookpartno.dita
+++ b/specification/langRef/technicalContent/bookpartno.dita
@@ -3,10 +3,8 @@
  "reference.dtd">
 <reference id="bookpartno" xml:lang="en-us">
   <title><xmlelement>bookpartno</xmlelement></title>
-  <shortdesc>The <xmlelement>bookpartno</xmlelement> element contains the part number of the book,
-    such as 99F1234.<draft-comment author="tammy">I don't fully understand how this element is to be
-      used. Usage information suggests that it can be used by the publisher. Does it have other
-      uses?</draft-comment></shortdesc>
+  <shortdesc>The <xmlelement>bookpartno</xmlelement> element contains the part number of the
+    book.</shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/specification/langRef/technicalContent/bookrestriction.dita
+++ b/specification/langRef/technicalContent/bookrestriction.dita
@@ -30,8 +30,6 @@
       <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>value</xmlatt> attribute specifies any
         restrictions on the use of the material, such as declaring the information confidential or
         for licensed use only.</p>
-      <draft-comment author="tammy">This seems redundant since it's also captured in the Usage
-        information section.</draft-comment>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/change-summary.dita
+++ b/specification/langRef/technicalContent/change-summary.dita
@@ -18,8 +18,6 @@
       <title>Usage information</title>
       <p>The <xmlelement>change-summary</xmlelement> element contains the portion of the release
         note that might appear in a document.</p>
-      <draft-comment author="tammy">How/when would the change-summary appear in a
-        document?</draft-comment>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/chdesc.dita
+++ b/specification/langRef/technicalContent/chdesc.dita
@@ -2,12 +2,10 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA 2.x Reference//EN" "reference.dtd">
 <reference id="chdesc" xml:lang="en-us">
 <title><xmlelement>chdesc</xmlelement></title>
-<shortdesc>The <xmlelement>chdesc</xmlelement> element provides the content
-    of the second cell in a choice table row. This content <ph
-      rev="review-a">describes the option that people can take to complete
-      the step, and it explains the result of the choice, if it is not
-      immediately
-    obvious.</ph><!--It explains why the user would choose that option and might explain the result of the choice when it is not immediately obvious.--><!--<draft-comment author="robander" time="21 may 2021">Rather than describing this based on presentation (content of a description cell in a table row) can we describe it as the description of an option in a step, or description of an option in a choice table?</draft-comment>--></shortdesc>
+<shortdesc>The <xmlelement>chdesc</xmlelement> element provides the content of the second cell in a
+    choice table row. This content <ph rev="review-a">describes the option that people can take to
+      complete the step, and it explains the result of the choice, if it is not immediately
+      obvious.</ph></shortdesc>
 <prolog><metadata>
 <keywords><indexterm><xmlelement>chdesc</xmlelement></indexterm>
         <indexterm>choice tables<indexterm>descriptions</indexterm></indexterm>

--- a/specification/langRef/technicalContent/choption.dita
+++ b/specification/langRef/technicalContent/choption.dita
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA 2.x Reference//EN" "reference.dtd">
-<reference id="choption" xml:lang="en-us"><title><xmlelement>choption</xmlelement></title><shortdesc>The <xmlelement>choption</xmlelement> element contains the
-    content of the first cell in a choice table row. This content <ph
-      rev="review-a">labels</ph> the option that <ph rev="review-a"
-      >people</ph> can take to complete the
-    step.<!--<draft-comment author="robander" time="21 may 2021">Rather than describing this based on presentation (content of an option cell in a table row) can we describe it as an option for completing a step, or similar?</draft-comment>--></shortdesc><prolog><metadata><keywords>
+<reference id="choption" xml:lang="en-us"><title><xmlelement>choption</xmlelement></title><shortdesc>The <xmlelement>choption</xmlelement> element contains the content of the first cell in a
+    choice table row. This content <ph rev="review-a">labels</ph> the option that <ph rev="review-a"
+      >people</ph> can take to complete the step.</shortdesc><prolog><metadata><keywords>
         <indexterm>choice tables<indexterm>options</indexterm></indexterm><indexterm><xmlelement>choption</xmlelement></indexterm><indexterm>task elements<indexterm><xmlelement>choption</xmlelement></indexterm></indexterm></keywords></metadata></prolog><refbody>
     <section id="rendering-expectations">
       <title>Rendering expectations</title>

--- a/specification/langRef/technicalContent/diagnostics-general.dita
+++ b/specification/langRef/technicalContent/diagnostics-general.dita
@@ -108,14 +108,14 @@
           rev="review-e"/>
       </fig>
       <fig rev="review-e">
-        <title>Example: Rigorous diagnosis</title>
+        <title>TODO: Example Rigorous diagnosis</title>
         <p>
           <draft-comment author="Kristen J Eberlein" time="15 February 2023">
             <p>We discussed the car noise example at the 14 February 2023 DITA TC meeting. The
               consensus was to add a second example, which Stan Doherty will develop.</p>
           </draft-comment>
-          <draft-comment author="rodaande" time="5 May 2026">If we do not get an updated example for
-            this, we should remove the second figure.</draft-comment>
+          <draft-comment author="rodaande" time="5 May 2026">TODO: If we do not get an updated
+            example for this, we should remove the second figure.</draft-comment>
         </p>
         <codeblock/>
       </fig>

--- a/specification/langRef/technicalContent/glossSurfaceForm.dita
+++ b/specification/langRef/technicalContent/glossSurfaceForm.dita
@@ -6,8 +6,7 @@
   <shortdesc>The <xmlelement>glossSurfaceForm</xmlelement> element specifies how the term <ph
       rev="review-a-2024">that is</ph> specified by the <xmlelement>glossterm</xmlelement> element
     should appear in the text. The surface form is suitable to introduce the term in new contexts or
-    as the first
-    occurrence.<!--<draft-comment author="dawnstevens">I learned a lot more than I really wanted to about the surface form in linguistics to suggest this short description, as opposed to what was there: "an unambiguous presentation of the term that might combine multiple forms." Surface forms are " the way a linguistic unit (such as a word, phrase, or sentence) appears when it is actually spoken or written, as opposed to its underlying or abstract form." Surface forms may take into account phonology (to provide stress, intonation, and accent), test and plurals (the surface form of "go" is "goes" in 3rd person singular), and derivational (to change roots of words in various contexts), contextual (I'm might be a surface form of I am in informal speech). Ultimately, in my experience the only thing this is really used for is first-use occurrence of acronyms so they are spelled out. I wonder if we should use that use case only in this definition, rather than a more comprehensive scope. </draft-comment>--></shortdesc>
+    as the first occurrence.</shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/specification/langRef/technicalContent/glossUsage.dita
+++ b/specification/langRef/technicalContent/glossUsage.dita
@@ -22,8 +22,7 @@
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>glossUsage</xmlelement> element is specialized from
           <xmlelement>note</xmlelement>. It is defined in the glossary entry module.</p>
-      <!--<draft-comment author="dawnstevens">Although I realize the element is specialized from Note, I question the need to point out the type and othertype attributes; they don't seem to me to have any meaning in the content of a usage note. A usage note is type usage note, in my mind. Why would anyone specify any type or othertype?</draft-comment>-->
-      <!--<draft-comment author="robander" time="Jan 18, 2024">For every attribute that is defined, we need to include it in the attribute list, whether we expect it to be used or not. If we want to modify this (but not remove the attributes), then we need to modify the conref to "note" so that we pull in the attribute list, but then add an exception saying that these attributes will not typically be used, that the type is expected to be a scope usage note.</draft-comment>-->
+      <!--Noting for future editors: there were questions during review about whether the attributes section should highlight @type and @othertype. These are retained because the attributes section has to list all valid attributes. While we could create a custom attribute section here that both defines the attributes and states that they are not usually used on this element, it's easier and more consistent to continue reusing the full set of attributes from <note>.-->
     </section>
     <section conkeyref="reuse-note/attributes" id="attributes"/>
     <example id="example" otherprops="examples">

--- a/specification/langRef/technicalContent/groupcomp.dita
+++ b/specification/langRef/technicalContent/groupcomp.dita
@@ -20,17 +20,8 @@
     <section id="usage-information">
       <title>Usage information</title>
       <p>Each syntax group is a logical set of pieces of syntax that go together. The group
-        composite means that the items that make up the syntax diagram will be rendered close
-        together rather than being separated by a horizontal or vertical line, which is the usual
-        formatting method.</p>
-      <draft-comment author="Frank Wegmann" time="19 February 2023">
-        <p>The usage information mentions rendering and formatting in one and the same sentence,
-          while this is only about rendering here, if I'm not mistaken regarding our language use.
-          Please advise whether we should break it out in a section Rendering expectations.</p>
-        <p>Furthermore, I cannot observe this rendering expectation in the current DITA-OT
-          implementation: I get the same output for the code sample below, when e.g. using
-            <xmlelement>groupseq</xmlelement> instead of <xmlelement>groupcomp</xmlelement>. </p>
-      </draft-comment>
+        composite is used for items that will be rendered close together rather than being separated
+        by a horizontal or vertical line.</p>
     </section>
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/mathmlref.dita
+++ b/specification/langRef/technicalContent/mathmlref.dita
@@ -154,10 +154,6 @@
   &lt;!-- ... -->
 &lt;/root></codeblock>
       </fig>
-      <!--<fig><title>Referencing a specific <xmlelement>math</xmlelement> element within a document using keys</title><p>The following code sample shows how a <xmlelement>mathmlref</xmlelement> element can be used to reference a specific<xmlelement>math</xmlelement> element in a containing document by using keys. The <xmlelement>math</xmlelement> element has an <xmlatt>id</xmlatt> attribute with the value of <keyword>equation-02</keyword>.</p><p>The key is defined as follows:</p><codeblock>&lt;keydef keys="mathml-equation-02" href="math/mathml-equations.xml#equation-02"
-                 <b>format="mathml"</b>/></codeblock><p>Then refer to this key using just the key name:</p><codeblock>&lt;mathml>
-  <b>&lt;mathmlref keyref="mathml-equation-02"/></b>
-&lt;/mathml></codeblock><p><draft-comment author="nancylph" time="21 may 2021"><p>This is a pretty standard way of defining and using keys; do we really need to include this last example?</p></draft-comment></p></fig>-->
     </example>
   </refbody>
 </reference>

--- a/specification/langRef/technicalContent/month.dita
+++ b/specification/langRef/technicalContent/month.dita
@@ -3,9 +3,8 @@
  "reference.dtd">
 <reference id="month" xml:lang="en-us">
   <title><xmlelement>month</xmlelement></title>
-  <shortdesc>The <xmlelement>month</xmlelement> element denotes a month of the year.<draft-comment
-      author="tammy">Are there any expectations to provide the month number vs. the
-      name?</draft-comment></shortdesc>
+  <!--Noted during review, this does not specify whether the month is a number (10) or name (October). Presumably both are legal, no change from 1.x description.-->
+  <shortdesc>The <xmlelement>month</xmlelement> element denotes a month of the year.</shortdesc>
   <prolog>
     <metadata>
       <keywords>

--- a/specification/langRef/technicalContent/publisherinformation.dita
+++ b/specification/langRef/technicalContent/publisherinformation.dita
@@ -15,12 +15,6 @@
     </metadata>
   </prolog>
   <refbody>
-    <section id="usage-information">
-      <title>Usage information</title>
-      <p>Additional information about the publication history is found in the
-          <xmlelement>bookchangehistory</xmlelement> element.</p>
-      <draft-comment author="tammy">I think this can be removed. Thoughts?</draft-comment>
-    </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>
       <p>The <xmlelement>publisherinformation</xmlelement> element is specialized from

--- a/specification/langRef/technicalContent/publishtype.dita
+++ b/specification/langRef/technicalContent/publishtype.dita
@@ -29,8 +29,6 @@
       <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
       <p id="attr-exception" outputclass="attr-exception">For this element, the <xmlatt>value</xmlatt> attribute specifies any
         restrictions on the availability of the publication.</p>
-      <draft-comment author="tammy">This seems redundant since it's also captured in the Usage
-        information section.</draft-comment>
     </section>
     <example id="example" otherprops="examples">
       <title>Example</title>

--- a/specification/langRef/technicalContent/refbodydiv.dita
+++ b/specification/langRef/technicalContent/refbodydiv.dita
@@ -49,7 +49,7 @@
 &lt;/reference>
 </codeblock>
       <draft-comment author="Kristen J Eberlein" time="26 October 2022">
-        <p>Can someone come up with a more realistic example?</p>
+        <p>TODO: Can someone come up with a more realistic example?</p>
       </draft-comment>
     </example>
 </refbody>

--- a/specification/langRef/technicalContent/reference.dita
+++ b/specification/langRef/technicalContent/reference.dita
@@ -31,6 +31,7 @@
       <title>Example</title>
       <draft-comment author="Kristen J Eberlein" time="08 November 2022">
         <p>This is a pretty lousy example ...</p>
+        <p>TODO: ask for a better example</p>
       </draft-comment>
       <p>The following code sample shows how a reference topic can be
         used:</p>

--- a/specification/langRef/technicalContent/revisionid.dita
+++ b/specification/langRef/technicalContent/revisionid.dita
@@ -16,10 +16,10 @@
   <refbody>
     <section id="processing-expectations">
       <title>Processing expectations</title>
-      <p>A processor determines how or whether the revision level is displayed. Common methods
-        include using a dash, for example "-01", or a period, such as ".01".</p>
-      <draft-comment author="tammy">I don't understand these processing
-        expectations.</draft-comment>
+      <p>A processor determines how or whether the revision level is displayed to highlight revised
+        content. <ph otherprops="example">For example, a processor could choose to indicate a
+          revision number of <keyword>01</keyword> by adding <keyword>-01</keyword> or
+            <keyword>.01</keyword> to the end of the book's part number.</ph></p>
     </section>
     <section id="specialization-hierarchy">
       <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/svgref.dita
+++ b/specification/langRef/technicalContent/svgref.dita
@@ -136,12 +136,6 @@
   &lt;/part>
 &lt;/root></codeblock></p>
       </fig>
-      <!--<p>The following example shows how to define a key in order to use <xmlelement>svg</xmlelement> to include an SVG fragment with the <xmlatt>id</xmlatt> of "svg-fragment-02" from within a larger document:<codeblock id="codeblock_w1r_ktn_ywb">&lt;keydef 
-  keys="svg-fragment-0002" 
-  href="svg/svg-library.xml#svg-fragment-02"
-/></codeblock>Then refer to this key using just the key name:<codeblock id="codeblock_x1r_ktn_ywb">&lt;svg-container>
-  &lt;svgref keyref="svg-fragment-0002"/>
-&lt;/svg-container></codeblock></p><draft-comment author="nancylph" time="21 may 2021"><p>This is a pretty standard way of defining and using keys; do we really need to include this last example?</p></draft-comment>-->
     </example>
   </refbody>
 </reference>


### PR DESCRIPTION
Making a pass through the tech-comm spec to resolve outstanding draft comments. As part of this, I'm also removing some that have been commented out; if the commented-out `<draft-comment>` stores info that might be useful in the future, I'm moving it to an ordinary XML comment.