### PR TITLE
Move task shell description per draft comment

### DIFF
--- a/specification/archSpec/technicalContent/task.dita
+++ b/specification/archSpec/technicalContent/task.dita
@@ -2,9 +2,26 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA 2.x Concept//EN" "concept.dtd">
 <concept id="task">
     <title>Task</title>
-    <shortdesc>DITA offer two varieties of task topics: general task and
-    strict task. <ph rev="review-a">Both task topics serve the same
-      purpose: to provide users with comprehensive instructions for
-      performing a task. Their content models vary,
-    however.</ph></shortdesc>
+    <shortdesc>The OASIS DITA Technical Committee distributes two varieties of task topics: general
+    task and strict task. <ph rev="review-a">Both task topics serve the same purpose: to provide
+      users with comprehensive instructions for performing a task. Their content models vary,
+      however.</ph></shortdesc>
+  <conbody>
+    <section id="section_1">
+      <dl id="dl_lzd_rrp_2jc">
+        <dlentry>
+          <dt>General task</dt>
+          <dd>Has a more relaxed content model. It allows <xmlelement>section</xmlelement> and
+              <xmlelement>steps-informal</xmlelement> inside of the task body; it also allows
+            multiple instances and varying order for the elements that make up the task body.</dd>
+        </dlentry>
+        <dlentry>
+          <dt>(Strict) task</dt>
+          <dd>Maintains a strict order and cardinality for elements within the
+              <xmlelement>taskbody</xmlelement> content model. The strict task is implemented with a
+            constraint module.</dd>
+        </dlentry>
+      </dl>
+    </section>
+  </conbody>
 </concept>

--- a/specification/common/key-definitions-tc-archspec-topics.ditamap
+++ b/specification/common/key-definitions-tc-archspec-topics.ditamap
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 2.x Map//EN" "map.dtd">
+<map>
+  <title>Key definitions: Technical content architectural topics</title>
+  <keydef keys="task-architecture" href="../archSpec/technicalContent/task.dita">
+    <topicmeta>
+      <linktitle>General task and strict task</linktitle>
+    </topicmeta>
+  </keydef>
+</map>

--- a/specification/dita-2.0-technical-content-specification.ditamap
+++ b/specification/dita-2.0-technical-content-specification.ditamap
@@ -38,6 +38,7 @@
       href="baseSpec/specification/common/key-definitions-oasis-boilerplate.ditamap"/>
     <mapref href="common/key-definitions-tc-library-topics.ditamap"/>
     <mapref href="common/key-definitions-tc-images.ditamap"/>
+    <mapref href="common/key-definitions-tc-archspec-topics.ditamap"/>
     <mapref href="baseSpec/specification/common/key-definitions-library-topics.ditamap"/>
     <mapref href="baseSpec/specification/common/key-definitions-reuse-w-lwdita.ditamap"/>
     <mapref href="langRef/key-definitions-tc-elements.ditamap"/>

--- a/specification/langRef/technicalContent/task.dita
+++ b/specification/langRef/technicalContent/task.dita
@@ -13,25 +13,9 @@
 <refbody>
   <section id="usage-information">
       <title>Usage information</title>
-      <p>The OASIS DITA Technical Committee distributes two document-type
-        shells for task topics: general task and strict task.</p>
-      <dl>
-        <dlentry>
-          <dt>General task</dt>
-          <dd>Has a more relaxed content model. It allows
-              <xmlelement>section</xmlelement> and
-              <xmlelement>steps-informal</xmlelement> inside of the task
-            body; it also allows multiple instances and varying order for
-            the elements that make up the task body.</dd>
-        </dlentry>
-        <dlentry>
-          <dt>(Strict) task</dt>
-          <dd>Maintains a strict order and cardinality for elements within the
-              <xmlelement>taskbody</xmlelement> content model. The strict task is implemented with a
-            constraint module.</dd>
-        </dlentry>
-      </dl>
-      <!--<draft-comment author="Kristen J Eberlein" time="07 October 2022"><p>I think this information, as currently written, belongs elsewere -\- perhaps in whatever overview topic we have about task.</p><p>Here, I think we just need to say that the content model for the task topic varies based on what document-type shell is in use. And honestly, I think the information should be in the <xmlelement>taskbody</xmlelement> topic rather than here.</p><p>For example: "The content model for the task topic varies depending on whether the (strict) task or general task document-type shell is in use."</p></draft-comment>-->
+      <p>The OASIS DITA Technical Committee distributes two document-type shells for task topics:
+        general task and strict task. See <xref keyref="task-architecture"/> for more information on
+        the different shells.</p>
     </section>
   <section id="specialization-hierarchy">
    <title>Specialization hierarchy</title>

--- a/specification/langRef/technicalContent/taskbody.dita
+++ b/specification/langRef/technicalContent/taskbody.dita
@@ -14,8 +14,9 @@
 <refbody>
       <section id="usage-information">
       <title>Usage information</title>
-      <p>The content model for the task topic varies depending on whether
-        the strict task or general task document-type shell is used.</p>
+      <p>The content model for the task topic varies depending on whether the strict task or general
+        task document-type shell is used. See <xref keyref="task-architecture"/> for more
+        information on the different shells.</p>
     </section>
 <section id="specialization-hierarchy">
 <title>Specialization hierarchy</title>

--- a/specification/technicalContent-relationship-tables.ditamap
+++ b/specification/technicalContent-relationship-tables.ditamap
@@ -2,24 +2,9 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 2.x Map//EN" "map.dtd">
 <map>
  <title>Relationship tables: Technical content specification</title>
+ <!--<reltable><title>External resources</title><relheader><relcolspec linking="sourceonly"/><relcolspec scope="external"/></relheader><relrow><relcell/><relcell/></relrow></reltable>-->
  <reltable>
-  <title>External resources</title>
-  <relheader>
-   <relcolspec linking="sourceonly"/>
-   <relcolspec scope="external"/>
-  </relheader>
-  
-
-  <relrow>
-   <relcell/>
-   <relcell/>
-  </relrow>
- </reltable>
- <reltable>
-  <relheader>
-   <relcolspec/>
-   <relcolspec/>
-  </relheader>
+  <title>General purpose bi-directional links in the technical content specification</title>
   <relrow>
    <relcell>
         <topicref href="langRef/containers/troubleshooting-elements.dita"/>
@@ -29,14 +14,6 @@
           href="archSpec/technicalContent/dita-troubleshooting-topic.dita"
         />
       </relcell>
-  </relrow>
-  <relrow>
-   <relcell/>
-   <relcell/>
-  </relrow>
-  <relrow>
-   <relcell/>
-   <relcell/>
   </relrow>
  </reltable>
 </map>


### PR DESCRIPTION
The `task` element ref topic contained a high level overview of the 2 task shells, and a draft comment suggesting those should be in the arch spec. This update
* Moves them into the task overview topic in the arch spec, where they fit with the 2 topics that give a deep overview of the two shells
* Link to that topic from both task and taskbody usage info
* Includes a bit of cleanup in the relationship table map, as I'd briefly considered adding links between these topics